### PR TITLE
add new (inactive) funding types

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.4.3</version>
+  <version>3.4.5</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/resources/db/migration/V3.35__update_funding_types.sql
+++ b/reference-service/src/main/resources/db/migration/V3.35__update_funding_types.sql
@@ -1,0 +1,7 @@
+INSERT INTO FundingType (code, label, status) VALUES ('HEE_FUNDED_TARIFF', 'HEE Funded - Tariff', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('HEE_FUNDED_NON_TARIFF', 'HEE Funded - Non-Tariff', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('TRUST_FUNDED', 'Trust Funded', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('ACADEMIC_NIHR', 'Academic - NIHR', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('ACADEMIC_HEE', 'Academic - HEE', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('ACADEMIC_TRUST', 'Academic - Trust', 'INACTIVE');
+INSERT INTO FundingType (code, label, status) VALUES ('SUPERNUMERARY', 'Supernumerary', 'INACTIVE');


### PR DESCRIPTION
There is a requirement to add some new funding types. We will be doing a migration to the new ones at a later point. These are added as inactive so won;t be visible to the users initially.