### PR TITLE
Fix failing unit test due to query change

### DIFF
--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNotNull;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 
@@ -199,7 +198,7 @@ public class ReferenceServiceImplTest {
     List<LocalOfficeDTO> respList = referenceServiceImpl.findLocalOfficesByName(localOfficeNameWithSpecialCharacters);
 
     // then
-    verify(referenceRestTemplate).exchange(eq(REFERENCE_URL + "/api/local-offices?columnFilters=%7B%22localOfficeName%22%3A%5B%22PARAMETER_localOfficeNameWithSpecialCharacters%40%21%C2%A3%26%C2%A3%24%25%40%2F%5C%22%5D%2C%22status%22%3A%5B%22CURRENT%22%5D%7D"),
+    verify(referenceRestTemplate).exchange(eq(REFERENCE_URL + "/api/local-offices?columnFilters=%7B%22name%22%3A%5B%22localOfficeNameWithSpecialCharacters%40%21%C2%A3%26%C2%A3%24%25%40%2F%5C%22%5D%2C%22status%22%3A%5B%22CURRENT%22%5D%7D"),
         eq(HttpMethod.GET), isNull(RequestEntity.class),
         Matchers.<ParameterizedTypeReference<java.util.List<com.transformuk.hee.tis.reference.api.dto.SiteDTO>>>any());
     assertEquals(localOffices, respList);


### PR DESCRIPTION
The local office by name query string was changed to be correct but the
test was not updated to reflect that. Update ReferenceServiceImplTest to
resolve the unit test failure.