### PR TITLE
chore: Move dockerization to local dockerfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,8 +74,13 @@ node {
               env.IMAGE_NAME = imageName
           }
 
-          sh "ansible-playbook -i $env.DEVOPS_BASE/ansible/inventory/dev $env.DEVOPS_BASE/ansible/tasks/spring-boot-build.yml"
+          sh "mvn package -DskipTests"
+          sh "cp ./reference-service/target/reference-service-*.war ./reference-service/target/app.jar"
+          sh "docker build -t heetiscontainerregistry.azurecr.io/reference:$buildVersion -f ./reference-service/Dockerfile ./reference-service"
+          sh "docker push heetiscontainerregistry.azurecr.io/reference:$buildVersion"
 
+          sh "docker tag heetiscontainerregistry.azurecr.io/reference:$buildVersion heetiscontainerregistry.azurecr.io/reference:latest"
+          sh "docker push heetiscontainerregistry.azurecr.io/reference:latest"
           println "[Jenkinsfile INFO] Stage Dockerize completed..."
         }
 

--- a/reference-service/Dockerfile
+++ b/reference-service/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-alpine
+
+EXPOSE 8088
+
+COPY target/app.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
The jenkins pipeline currently dockerizes the reference service via
ansible script, update the jenkins pipeline to use a newly created
Dockerfile instead.

TISNEW-3465