### PR TITLE
chore: Skip branch and PR builds in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,12 @@ def utils = new hee.tis.utils()
 
 node {
 
+    if (env.BRANCH_NAME != "master") {
+        // Flagged as successful to avoid PRs appearing to fail checks.
+        currentBuild.result = 'SUCCESS'
+        return
+    }
+
     def service = "reference"
     def containerRegistryLocaltion = "430723991443.dkr.ecr.eu-west-2.amazonaws.com"
 


### PR DESCRIPTION
PR builds are now done via Github Actions.

TISNEW-5708