### PR TITLE
chore: Resync HEE and NIMDTA DBC tables

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.19.0</version>
+  <version>3.19.1</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/resources/db/migration/tenant/hee/V3.57__insert_external_dbcs.sql
+++ b/reference-service/src/main/resources/db/migration/tenant/hee/V3.57__insert_external_dbcs.sql
@@ -1,0 +1,2 @@
+INSERT INTO `DBC`(`dbc`, `name`, `abbr`, `status`, `uuid`)
+VALUES('1-25U-830', 'Northern Ireland Medical and Dental Training Agency', 'NIMDTA', 'CURRENT', 'd7a270ad-5a1b-11eb-b9f5-06521f467108');

--- a/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.57__insert_external_dbcs.sql
+++ b/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.57__insert_external_dbcs.sql
@@ -1,0 +1,5 @@
+INSERT INTO `DBC`(`dbc`, `name`, `abbr`, `status`, `uuid`)
+VALUES
+  ('1-8W6121', 'NHS Education for Scotland', 'NES', 'CURRENT', '60c553ae-8d71-11eb-9f9a-0638a616fc76'),
+  ('1-36QUOY', 'Health Education and Improvement Wales', 'HEIW', 'CURRENT', '792bc920-8d71-11eb-9f9a-0638a616fc76'),
+  ('1-2SXJST', 'Defence Postgraduate Medical Deanery', 'DPMD', 'CURRENT', '811f478c-8d71-11eb-9f9a-0638a616fc76');


### PR DESCRIPTION
Several entries have been added to the HEE table and one added to the
NIMDTA. These need to be populated in the opposite database with
matching UUIDs.

TIS21-1140