### PR TITLE
Revert "chore(deps): bump javax.servlet-api from 4.0.0-b03 to 4.0.1"

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -32,7 +32,7 @@
     <hikaricp.version>3.2.0</hikaricp.version>
     <java.version>1.8</java.version>
     <javassist.version>3.21.0-GA</javassist.version>
-    <javax.servlet.version>4.0.1</javax.servlet.version>
+    <javax.servlet.version>4.0.0-b03</javax.servlet.version>
     <jhipster.server.version>1.3.1</jhipster.server.version>
     <jjwt.version>0.7.0</jjwt.version>
     <logstash-logback-encoder.version>4.8</logstash-logback-encoder.version>


### PR DESCRIPTION
Reverts Health-Education-England/TIS-REFERENCE#142

Suspected to be causing issues with monitoring.