### PR TITLE
fix: Update trustId based on trustCode

### DIFF
--- a/reference-service/src/main/resources/db/migration/common/V3.62__fix_trustid_not_matching_trustcodes_of_sites.sql
+++ b/reference-service/src/main/resources/db/migration/common/V3.62__fix_trustid_not_matching_trustcodes_of_sites.sql
@@ -1,0 +1,4 @@
+UPDATE `Site` site
+INNER JOIN `Trust` trust ON site.trustCode = trust.code AND site.status = trust.status
+SET site.trustId = trust.id
+WHERE site.trustId != trust.id AND site.status = 'CURRENT';


### PR DESCRIPTION
A bug led to live data being inaccurate due to `trustIds` of a Site mismatching its `trustCode`. 
With this flyway script, all CURRENT Sites will be updated to have the correct `trustId` of a CURRENT trust.

The aim of the script is to affect all rows in Site where the `status` is `CURRENT`, take the `trustCode` from each row, fetch the `CURRENT` Trust that goes by that code (`CURRENT` `trustCodes` are unique now, so one Trust is found per `trustCode`), and update the `trustId` field in Site with it.


**TIS21-1824**: Fix Sites with the wrong trustId