### PR TITLE
Refactor/tweak message of exception in trust validator tis21 1840

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.25.0</version>
+  <version>3.25.1</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/validation/TrustValidator.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/validation/TrustValidator.java
@@ -16,8 +16,6 @@ public class TrustValidator {
 
   private final TrustRepository repository;
 
-  private static final String ERROR_MESSAGE_NOT_UNIQUE = "Trust failed validation due to non-unique code ";
-
   public TrustValidator(TrustRepository repository) {
     this.repository = repository;
   }
@@ -33,8 +31,10 @@ public class TrustValidator {
       existingTrusts.removeIf(t -> t.getId().equals(id));
 
       if (!existingTrusts.isEmpty()) {
-          log.warn(ERROR_MESSAGE_NOT_UNIQUE + "'{}'.", code);
-        throw new CustomParameterizedException(ERROR_MESSAGE_NOT_UNIQUE + code, ErrorConstants.ERR_VALIDATION);
+        String ERROR_MESSAGE_NOT_UNIQUE = "Trust failed validation due to non-unique code ";
+        log.warn(ERROR_MESSAGE_NOT_UNIQUE + "'{}'.", code);
+        throw new CustomParameterizedException(ERROR_MESSAGE_NOT_UNIQUE + code,
+            ErrorConstants.ERR_VALIDATION);
       }
     }
   }


### PR DESCRIPTION
Message used in _log.warn_ also used as the message of the CustomParameterizedException thrown by TrustValidator, so that it can be picked up by the frontend.