### PR TITLE
fix: Change DBC.internal to bit

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.25.1</version>
+  <version>3.25.2</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/resources/db/migration/common/V3.65__change_dbc_internal_to_bit.sql
+++ b/reference-service/src/main/resources/db/migration/common/V3.65__change_dbc_internal_to_bit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `DBC` MODIFY COLUMN `internal` bit(1);


### PR DESCRIPTION
The `internal` field was created as `tinybit(1)` to represent a boolean,
but this is inconsistent with other existing tables which use `bit(1)`.

TIS21-1659