### PR TITLE
feat: Add GET endpoint for role categories

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.26.0</version>
+  <version>3.27.0</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleCategoryResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleCategoryResource.java
@@ -1,0 +1,51 @@
+package com.transformuk.hee.tis.reference.service.api;
+
+import com.transformuk.hee.tis.reference.api.dto.RoleCategoryDTO;
+import com.transformuk.hee.tis.reference.service.model.RoleCategory;
+import com.transformuk.hee.tis.reference.service.repository.RoleCategoryRepository;
+import com.transformuk.hee.tis.reference.service.service.mapper.RoleCategoryMapper;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller for managing Role Categories.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/role-categories")
+public class RoleCategoryResource {
+
+  private final RoleCategoryRepository repository;
+  private final RoleCategoryMapper mapper;
+
+  public RoleCategoryResource(RoleCategoryRepository repository, RoleCategoryMapper mapper) {
+    this.repository = repository;
+    this.mapper = mapper;
+  }
+
+  /**
+   * GET  : get all roles categories.
+   *
+   * @return the ResponseEntity with status 200 (OK) and the list of roles categories the in body.
+   */
+  @ApiOperation(value = "Lists role categories", notes = "Returns a list of role categories")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "role category list")
+  })
+  @GetMapping
+  public ResponseEntity<List<RoleCategoryDTO>> getAllRoleCategories() {
+    log.info("REST request to get all role categories received.");
+    List<RoleCategory> roleCategories = repository.findAll(Sort.by("name"));
+    List<RoleCategoryDTO> roleCategoryDtos = mapper
+        .roleCategorysToRoleCategoryDTOs(roleCategories);
+    return ResponseEntity.ok(roleCategoryDtos);
+  }
+}

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleCategoryResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleCategoryResourceIntTest.java
@@ -1,0 +1,69 @@
+package com.transformuk.hee.tis.reference.service.api;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.transformuk.hee.tis.reference.service.Application;
+import com.transformuk.hee.tis.reference.service.model.RoleCategory;
+import com.transformuk.hee.tis.reference.service.repository.RoleCategoryRepository;
+import com.transformuk.hee.tis.reference.service.service.mapper.RoleCategoryMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Test class for the RoleResource REST controller.
+ *
+ * @see RoleResource
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = Application.class)
+public class RoleCategoryResourceIntTest {
+
+  @Autowired
+  private RoleCategoryRepository repository;
+
+  @Autowired
+  private RoleCategoryMapper mapper;
+
+  @Autowired
+  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+  private MockMvc mockMvc;
+
+  @Before
+  public void setup() {
+    MockitoAnnotations.openMocks(this);
+    RoleCategoryResource resource = new RoleCategoryResource(repository, mapper);
+    this.mockMvc = MockMvcBuilders.standaloneSetup(resource)
+        .setMessageConverters(jacksonMessageConverter).build();
+  }
+
+  @Test
+  @Transactional
+  public void shouldGetAllRoleCategories() throws Exception {
+    // Initialize the database
+    RoleCategory roleCategory = new RoleCategory();
+    roleCategory.setName("categoryName");
+    repository.saveAndFlush(roleCategory);
+
+    // Get all the roleList
+    mockMvc.perform(get("/api/role-categories"))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+        .andExpect(jsonPath("$.[*].id").value(hasItem(roleCategory.getId().intValue())))
+        .andExpect(jsonPath("$.[*].name").value(hasItem("categoryName")));
+  }
+}


### PR DESCRIPTION
The reference manage table for Role requires a list of role categories,
add a GET endpoint to retrieve the full list of categories.

TIS21-499