### PR TITLE
feat: add client method to get all AssessmentTypes

### DIFF
--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-client</artifactId>
-  <version>4.11.3</version>
+  <version>4.11.4</version>
 
   <properties>
     <java.version>1.8</java.version>

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.reference.client;
 
 import com.transformuk.hee.tis.client.ClientService;
+import com.transformuk.hee.tis.reference.api.dto.AssessmentTypeDto;
 import com.transformuk.hee.tis.reference.api.dto.DBCDTO;
 import com.transformuk.hee.tis.reference.api.dto.FundingTypeDTO;
 import com.transformuk.hee.tis.reference.api.dto.GradeDTO;
@@ -99,6 +100,13 @@ public interface ReferenceService extends ClientService {
    * @return The found trust.
    */
   TrustDTO findTrustById(Long id);
+
+  /**
+   * Find all AssessmentTypes.
+   *
+   * @return the list of AssessmentTypes
+   */
+  List<AssessmentTypeDto> findAllAssessmentTypes();
 
   List<LocalOfficeDTO> findLocalOfficesByName(String localOfficeName);
 

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -116,6 +116,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   private static final String QUALIFICATION_TYPE_MAPPINGS_ENDPOINT =
       "/api/qualification-types/exists/";
   private static final String ROLES_BY_ROLE_CATEGORY = "/api/roles/categories/";
+  private static final String ASSESSMENT_TYPES_ENDPOINT = "/api/assessment-types";
 
   private static String gradesJsonQuerystringURLEncoded;
   private static String labelJsonQuerystringURLEncoded;
@@ -303,6 +304,11 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
 
   private ParameterizedTypeReference<HttpStatus> getSiteTrustMatchReference() {
     return new ParameterizedTypeReference<HttpStatus>() {
+    };
+  }
+
+  private ParameterizedTypeReference<List<AssessmentTypeDto>> getAssessmentTypes() {
+    return new ParameterizedTypeReference<List<AssessmentTypeDto>>() {
     };
   }
 
@@ -709,6 +715,14 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   public Set<DBCDTO> getAllDBCs() {
     ResponseEntity<Set<DBCDTO>> responseEntity = referenceRestTemplate
         .exchange(serviceUrl + "/api/dbcs?size=100&page=0", HttpMethod.GET, null, getDBCDto());
+    return responseEntity.getBody();
+  }
+
+  @Override
+  public List<AssessmentTypeDto> findAllAssessmentTypes() {
+    ResponseEntity<List<AssessmentTypeDto>> responseEntity = referenceRestTemplate
+        .exchange(serviceUrl + ASSESSMENT_TYPES_ENDPOINT + "?size=3000&page=0&columnFilters=" + statusCurrentUrlEncoded,
+            HttpMethod.GET, null, getAssessmentTypes());
     return responseEntity.getBody();
   }
 }


### PR DESCRIPTION
Assessment bulk update needs to validate AssessmentTypes. This PR is to add the client to fetch all AssessmentTypes.
At the moment, we just have 5 AssessmentTypes, but page size 3000 in the URL is the same as what the TIS UI uses.

TIS21-181