### PR TITLE
feat: add Acadmic column in FundingType table

### DIFF
--- a/reference-api/pom.xml
+++ b/reference-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-api</artifactId>
-  <version>2.10.0</version>
+  <version>2.10.1</version>
 
   <properties>
     <java.version>1.8</java.version>

--- a/reference-api/src/main/java/com/transformuk/hee/tis/reference/api/dto/FundingTypeDTO.java
+++ b/reference-api/src/main/java/com/transformuk/hee/tis/reference/api/dto/FundingTypeDTO.java
@@ -25,6 +25,8 @@ public class FundingTypeDTO implements Serializable {
 
   private Status status;
 
+  private boolean academic;
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-client</artifactId>
-  <version>4.11.4</version>
+  <version>4.11.5</version>
 
   <properties>
     <java.version>1.8</java.version>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-api</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.1</version>
     </dependency>
 
     <dependency>

--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.27.1</version>
+  <version>3.27.2</version>
   <packaging>war</packaging>
 
   <prerequisites>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-api</artifactId>
-      <version>2.10.0</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
@@ -84,6 +84,7 @@ public class FundingTypeResource {
           .createFailureAlert(ENTITY_NAME, "idexists",
               "A new fundingType cannot already have an ID")).body(null);
     }
+    fundingTypeDTO.setAcademic(false); // set default to false
     FundingType fundingType = fundingTypeMapper.fundingTypeDTOToFundingType(fundingTypeDTO);
     fundingType = fundingTypeRepository.save(fundingType);
     FundingTypeDTO result = fundingTypeMapper.fundingTypeToFundingTypeDTO(fundingType);

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
@@ -42,6 +42,10 @@ public class FundingType implements Serializable {
   @Column(name = "status")
   private Status status;
 
+  @NotNull
+  @Column(name = "academic", nullable = false)
+  private boolean academic;
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/reference-service/src/main/resources/db/migration/common/V3.66__add_column_to_funding_type.sql
+++ b/reference-service/src/main/resources/db/migration/common/V3.66__add_column_to_funding_type.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `FundingType`
+ADD COLUMN `academic` bit DEFAULT 0;
+
+UPDATE `FundingType`
+SET academic = 1
+WHERE code IN (
+  'ACADEMIC_NIHR',
+  'ACADEMIC_HEE',
+  'ACADEMIC_TRUST',
+  'SUPERNUMERARY'
+);

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResourceIntTest.java
@@ -84,6 +84,7 @@ public class FundingTypeResourceIntTest {
     FundingType fundingType = new FundingType();
     fundingType.setCode(DEFAULT_CODE);
     fundingType.setLabel(DEFAULT_LABEL);
+    fundingType.setAcademic(false);
     return fundingType;
   }
 
@@ -119,6 +120,7 @@ public class FundingTypeResourceIntTest {
     List<FundingType> fundingTypeList = fundingTypeRepository.findAll();
     assertThat(fundingTypeList).hasSize(databaseSizeBeforeCreate + 1);
     FundingType testFundingType = fundingTypeList.get(fundingTypeList.size() - 1);
+    assertThat(testFundingType.isAcademic()).isEqualTo(false);
     assertThat(testFundingType.getCode()).isEqualTo(DEFAULT_CODE);
     assertThat(testFundingType.getLabel()).isEqualTo(DEFAULT_LABEL);
   }
@@ -193,7 +195,8 @@ public class FundingTypeResourceIntTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(jsonPath("$.[*].id").value(hasItem(fundingType.getId().intValue())))
         .andExpect(jsonPath("$.[*].code").value(hasItem(DEFAULT_CODE.toString())))
-        .andExpect(jsonPath("$.[*].label").value(hasItem(DEFAULT_LABEL.toString())));
+        .andExpect(jsonPath("$.[*].label").value(hasItem(DEFAULT_LABEL.toString())))
+        .andExpect(jsonPath("$.[*].academic").value(hasItem(false)));
   }
 
   @Test


### PR DESCRIPTION
For this ticket, it needs to distinguish if the funding type in a Post is an academic one to check if the 'FundingDetails' field is enabled.

There're two ways to implement this:
1. hard code those academic types on Frontend and other services.
    In assessment section, some condition of the population of 'Academic curriculum assessed' uses hard code too.
2. add a new 'academic' field in 'FundingType' table, so that other services will know if it's academic when they get data from this table. And this also helps data consistency between services.

So the 2nd has been chosen.

The 'academic' field won't be shown on 'Admin / Funding Type' reference table, and once a new funding type is added in the UI, the 'academic' field will be set to `false`. So this field is for internal use only.

TIS21-437