### PR TITLE
Feat/change roles exist

### DIFF
--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-client</artifactId>
-  <version>4.11.5</version>
+  <version>4.11.6</version>
 
   <properties>
     <java.version>1.8</java.version>

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
@@ -122,6 +122,8 @@ public interface ReferenceService extends ClientService {
 
   Map<Long, Boolean> gradeIdsExists(List<Long> ids);
 
+  Map<String, Boolean> rolesExist(List<String> codes, boolean currentOnly);
+
   Map<String, String> rolesMatch(List<String> codes, boolean currentOnly);
 
   Map<String, Boolean> trustExists(List<String> Ids);

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
@@ -122,7 +122,7 @@ public interface ReferenceService extends ClientService {
 
   Map<Long, Boolean> gradeIdsExists(List<Long> ids);
 
-  Map<String, String> rolesExist(List<String> codes, boolean currentOnly);
+  Map<String, String> rolesMatch(List<String> codes, boolean currentOnly);
 
   Map<String, Boolean> trustExists(List<String> Ids);
 

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
@@ -122,7 +122,7 @@ public interface ReferenceService extends ClientService {
 
   Map<Long, Boolean> gradeIdsExists(List<Long> ids);
 
-  Map<String, Boolean> rolesExist(List<String> codes, boolean currentOnly);
+  Map<String, String> rolesExist(List<String> codes, boolean currentOnly);
 
   Map<String, Boolean> trustExists(List<String> Ids);
 

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -277,6 +277,11 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     };
   }
 
+  private ParameterizedTypeReference<Map<String, String>> getExistsStrReference() {
+    return new ParameterizedTypeReference<Map<String, String>>() {
+    };
+  }
+
   private ParameterizedTypeReference<Map<Long, Boolean>> getExistsLongReference() {
     return new ParameterizedTypeReference<Map<Long, Boolean>>() {
     };
@@ -325,6 +330,15 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(ids);
     ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsReference();
     ResponseEntity<Map<String, Boolean>> responseEntity = referenceRestTemplate
+        .exchange(url, HttpMethod.POST, requestEntity,
+            responseType);
+    return responseEntity.getBody();
+  }
+
+  private Map<String, String> existsString(String url, List<String> ids) {
+    HttpEntity<List<String>> requestEntity = new HttpEntity<>(ids);
+    ParameterizedTypeReference<Map<String, String>> responseType = getExistsStrReference();
+    ResponseEntity<Map<String, String>> responseEntity = referenceRestTemplate
         .exchange(url, HttpMethod.POST, requestEntity,
             responseType);
     return responseEntity.getBody();
@@ -570,14 +584,14 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   }
 
   @Override
-  public Map<String, Boolean> rolesExist(List<String> codes, boolean currentOnly) {
+  public Map<String, String> rolesExist(List<String> codes, boolean currentOnly) {
     String url = serviceUrl + ROLES_MAPPINGS_ENDPOINT;
 
     if (currentOnly) {
       url += "?columnFilters=" + statusCurrentUrlEncoded;
     }
 
-    return exists(url, codes);
+    return existsString(url, codes);
   }
 
   @Override

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -91,7 +91,8 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   private static final String SITE_TRUST_MATCH_ENDPOINT = "/api/sites/trustmatch/";
   private static final String GRADES_MAPPINGS_ENDPOINT = "/api/grades/exists/";
   private static final String GRADES_IDS_MAPPINGS_ENDPOINT = "/api/grades/ids/exists/";
-  private static final String ROLES_MAPPINGS_ENDPOINT = "/api/roles/matches/";
+  private static final String ROLES_MAPPINGS_ENDPOINT = "/api/roles/exists/";
+  private static final String ROLES_MATCHING_MAPPINGS_ENDPOINT = "/api/roles/matches/";
   private static final String SITES_MAPPINGS_ENDPOINT = "/api/sites/exists/";
   private static final String SITES_IDS_MAPPINGS_ENDPOINT = "/api/sites/ids/exists/";
   private static final String TRUSTS_MAPPINGS_ENDPOINT = "/api/trusts/exists/";
@@ -461,7 +462,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     LOG.debug("calling getRolesByCategory with {}", categoryId);
 
     return referenceRestTemplate
-        .exchange(serviceUrl + ROLES_BY_ROLE_CATEGORY + String.valueOf(categoryId), HttpMethod.GET,
+        .exchange(serviceUrl + ROLES_BY_ROLE_CATEGORY + categoryId, HttpMethod.GET,
             null, new ParameterizedTypeReference<List<RoleDTO>>() {
             })
         .getBody();
@@ -584,8 +585,19 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   }
 
   @Override
-  public Map<String, String> rolesMatch(List<String> codes, boolean currentOnly) {
+  public Map<String, Boolean> rolesExist(List<String> codes, boolean currentOnly) {
     String url = serviceUrl + ROLES_MAPPINGS_ENDPOINT;
+
+    if (currentOnly) {
+      url += "?columnFilters=" + statusCurrentUrlEncoded;
+    }
+
+    return exists(url, codes);
+  }
+
+  @Override
+  public Map<String, String> rolesMatch(List<String> codes, boolean currentOnly) {
+    String url = serviceUrl + ROLES_MATCHING_MAPPINGS_ENDPOINT;
 
     if (currentOnly) {
       url += "?columnFilters=" + statusCurrentUrlEncoded;
@@ -735,7 +747,8 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   @Override
   public List<AssessmentTypeDto> findAllAssessmentTypes() {
     ResponseEntity<List<AssessmentTypeDto>> responseEntity = referenceRestTemplate
-        .exchange(serviceUrl + ASSESSMENT_TYPES_ENDPOINT + "?size=3000&page=0&columnFilters=" + statusCurrentUrlEncoded,
+        .exchange(serviceUrl + ASSESSMENT_TYPES_ENDPOINT + "?size=3000&page=0&columnFilters="
+                + statusCurrentUrlEncoded,
             HttpMethod.GET, null, getAssessmentTypes());
     return responseEntity.getBody();
   }

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -91,7 +91,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   private static final String SITE_TRUST_MATCH_ENDPOINT = "/api/sites/trustmatch/";
   private static final String GRADES_MAPPINGS_ENDPOINT = "/api/grades/exists/";
   private static final String GRADES_IDS_MAPPINGS_ENDPOINT = "/api/grades/ids/exists/";
-  private static final String ROLES_MAPPINGS_ENDPOINT = "/api/roles/exists/";
+  private static final String ROLES_MAPPINGS_ENDPOINT = "/api/roles/matches/";
   private static final String SITES_MAPPINGS_ENDPOINT = "/api/sites/exists/";
   private static final String SITES_IDS_MAPPINGS_ENDPOINT = "/api/sites/ids/exists/";
   private static final String TRUSTS_MAPPINGS_ENDPOINT = "/api/trusts/exists/";
@@ -277,7 +277,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     };
   }
 
-  private ParameterizedTypeReference<Map<String, String>> getCorrectsStringReference() {
+  private ParameterizedTypeReference<Map<String, String>> getMatchesStringReference() {
     return new ParameterizedTypeReference<Map<String, String>>() {
     };
   }
@@ -335,9 +335,9 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     return responseEntity.getBody();
   }
 
-  private Map<String, String> existsString(String url, List<String> ids) {
+  private Map<String, String> matchString(String url, List<String> ids) {
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(ids);
-    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectsStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getMatchesStringReference();
     ResponseEntity<Map<String, String>> responseEntity = referenceRestTemplate
         .exchange(url, HttpMethod.POST, requestEntity,
             responseType);
@@ -584,14 +584,14 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   }
 
   @Override
-  public Map<String, String> rolesExist(List<String> codes, boolean currentOnly) {
+  public Map<String, String> rolesMatch(List<String> codes, boolean currentOnly) {
     String url = serviceUrl + ROLES_MAPPINGS_ENDPOINT;
 
     if (currentOnly) {
       url += "?columnFilters=" + statusCurrentUrlEncoded;
     }
 
-    return existsString(url, codes);
+    return matchString(url, codes);
   }
 
   @Override

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -277,7 +277,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
     };
   }
 
-  private ParameterizedTypeReference<Map<String, String>> getExistsStrReference() {
+  private ParameterizedTypeReference<Map<String, String>> getCorrectsStringReference() {
     return new ParameterizedTypeReference<Map<String, String>>() {
     };
   }
@@ -337,7 +337,7 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
 
   private Map<String, String> existsString(String url, List<String> ids) {
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(ids);
-    ParameterizedTypeReference<Map<String, String>> responseType = getExistsStrReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectsStringReference();
     ResponseEntity<Map<String, String>> responseEntity = referenceRestTemplate
         .exchange(url, HttpMethod.POST, requestEntity,
             responseType);

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.reference.api.dto.AssessmentTypeDto;
@@ -376,7 +375,7 @@ public class ReferenceServiceImplTest {
     };
   }
 
-  private ParameterizedTypeReference<Map<String, String>> getCorrectStringReference() {
+  private ParameterizedTypeReference<Map<String, String>> getMatchesStringReference() {
     return new ParameterizedTypeReference<Map<String, String>>() {
     };
   }
@@ -1267,11 +1266,11 @@ public class ReferenceServiceImplTest {
   }
 
   @Test
-  public void shouldCheckAnyRolesExistsWhenNotCurrentOnly() {
+  public void shouldCheckAnyRolesMatchesWhenNotCurrentOnly() {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getMatchesStringReference();
 
     Map<String, String> response = new HashMap<>();
     response.put("code1", "code1");
@@ -1283,22 +1282,22 @@ public class ReferenceServiceImplTest {
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, String> exists = referenceServiceImpl.rolesExist(codes, false);
+    Map<String, String> exists = referenceServiceImpl.rolesMatch(codes, false);
 
     // Then.
     assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
     assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
     verify(referenceRestTemplate)
-        .exchange(REFERENCE_URL + "/api/roles/exists/", HttpMethod.POST, requestEntity,
+        .exchange(REFERENCE_URL + "/api/roles/matches/", HttpMethod.POST, requestEntity,
             responseType);
   }
 
   @Test
-  public void shouldCheckCurrentRolesExistsWhenCurrentOnly() {
+  public void shouldCheckCurrentRolesMatchesWhenCurrentOnly() {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getMatchesStringReference();
 
     Map<String, String> response = new HashMap<>();
     response.put("code1", "code1");
@@ -1310,13 +1309,13 @@ public class ReferenceServiceImplTest {
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, String> exists = referenceServiceImpl.rolesExist(codes, true);
+    Map<String, String> exists = referenceServiceImpl.rolesMatch(codes, true);
 
     // Then.
     assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
     assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
     verify(referenceRestTemplate).exchange(
-        REFERENCE_URL + "/api/roles/exists/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
+        REFERENCE_URL + "/api/roles/matches/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
         HttpMethod.POST, requestEntity, responseType);
   }
 

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.reference.api.dto.AssessmentTypeDto;
@@ -372,6 +373,11 @@ public class ReferenceServiceImplTest {
 
   private ParameterizedTypeReference<Map<String, Boolean>> getExistsStringReference() {
     return new ParameterizedTypeReference<Map<String, Boolean>>() {
+    };
+  }
+
+  private ParameterizedTypeReference<Map<String, String>> getCorrectStringReference() {
+    return new ParameterizedTypeReference<Map<String, String>>() {
     };
   }
 
@@ -1265,23 +1271,23 @@ public class ReferenceServiceImplTest {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectStringReference();
 
-    Map<String, Boolean> response = new HashMap<>();
-    response.put("code1", true);
-    response.put("code2", false);
+    Map<String, String> response = new HashMap<>();
+    response.put("code1", "code1");
+    response.put("code2", "");
 
     given(referenceRestTemplate
         .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
-            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+            Matchers.<ParameterizedTypeReference<Map<String, String>>>any()))
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, Boolean> exists = referenceServiceImpl.rolesExist(codes, false);
+    Map<String, String> exists = referenceServiceImpl.rolesExist(codes, false);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
     verify(referenceRestTemplate)
         .exchange(REFERENCE_URL + "/api/roles/exists/", HttpMethod.POST, requestEntity,
             responseType);
@@ -1292,23 +1298,23 @@ public class ReferenceServiceImplTest {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getCorrectStringReference();
 
-    Map<String, Boolean> response = new HashMap<>();
-    response.put("code1", true);
-    response.put("code2", false);
+    Map<String, String> response = new HashMap<>();
+    response.put("code1", "code1");
+    response.put("code2", "");
 
     given(referenceRestTemplate
         .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
-            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+            Matchers.<ParameterizedTypeReference<Map<String, String>>>any()))
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, Boolean> exists = referenceServiceImpl.rolesExist(codes, true);
+    Map<String, String> exists = referenceServiceImpl.rolesExist(codes, true);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
     verify(referenceRestTemplate).exchange(
         REFERENCE_URL + "/api/roles/exists/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
         HttpMethod.POST, requestEntity, responseType);

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -1339,8 +1339,8 @@ public class ReferenceServiceImplTest {
     Map<String, String> matches = referenceServiceImpl.rolesMatch(codes, false);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", matches.get("code1"), is("code1"));
-    assertThat("Unexpected 'exists' result value.", matches.get("code2"), is(""));
+    assertThat("Unexpected 'matches' result value.", matches.get("code1"), is("code1"));
+    assertThat("Unexpected 'matches' result value.", matches.get("code2"), is(""));
     verify(referenceRestTemplate)
         .exchange(REFERENCE_URL + "/api/roles/matches/", HttpMethod.POST, requestEntity,
             responseType);
@@ -1366,8 +1366,8 @@ public class ReferenceServiceImplTest {
     Map<String, String> matches = referenceServiceImpl.rolesMatch(codes, true);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", matches.get("code1"), is("code1"));
-    assertThat("Unexpected 'exists' result value.", matches.get("code2"), is(""));
+    assertThat("Unexpected 'matches' result value.", matches.get("code1"), is("code1"));
+    assertThat("Unexpected 'matches' result value.", matches.get("code2"), is(""));
     verify(referenceRestTemplate).exchange(
         REFERENCE_URL + "/api/roles/matches/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
         HttpMethod.POST, requestEntity, responseType);

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -1336,11 +1336,11 @@ public class ReferenceServiceImplTest {
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, String> exists = referenceServiceImpl.rolesMatch(codes, false);
+    Map<String, String> matches = referenceServiceImpl.rolesMatch(codes, false);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
+    assertThat("Unexpected 'exists' result value.", matches.get("code1"), is("code1"));
+    assertThat("Unexpected 'exists' result value.", matches.get("code2"), is(""));
     verify(referenceRestTemplate)
         .exchange(REFERENCE_URL + "/api/roles/matches/", HttpMethod.POST, requestEntity,
             responseType);
@@ -1363,11 +1363,11 @@ public class ReferenceServiceImplTest {
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, String> exists = referenceServiceImpl.rolesMatch(codes, true);
+    Map<String, String> matches = referenceServiceImpl.rolesMatch(codes, true);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("code1"));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
+    assertThat("Unexpected 'exists' result value.", matches.get("code1"), is("code1"));
+    assertThat("Unexpected 'exists' result value.", matches.get("code2"), is(""));
     verify(referenceRestTemplate).exchange(
         REFERENCE_URL + "/api/roles/matches/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
         HttpMethod.POST, requestEntity, responseType);

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -1266,6 +1266,60 @@ public class ReferenceServiceImplTest {
   }
 
   @Test
+  public void shouldCheckAnyRolesExistsWhenNotCurrentOnly() {
+    // Given.
+    List<String> codes = Arrays.asList("code1", "code2");
+    HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
+    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+
+    Map<String, Boolean> response = new HashMap<>();
+    response.put("code1", true);
+    response.put("code2", false);
+
+    given(referenceRestTemplate
+        .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
+            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+        .willReturn(ResponseEntity.ok(response));
+
+    // When.
+    Map<String, Boolean> exists = referenceServiceImpl.rolesExist(codes, false);
+
+    // Then.
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    verify(referenceRestTemplate)
+        .exchange(REFERENCE_URL + "/api/roles/exists/", HttpMethod.POST, requestEntity,
+            responseType);
+  }
+
+  @Test
+  public void shouldCheckCurrentRolesExistsWhenCurrentOnly() {
+    // Given.
+    List<String> codes = Arrays.asList("code1", "code2");
+    HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
+    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+
+    Map<String, Boolean> response = new HashMap<>();
+    response.put("code1", true);
+    response.put("code2", false);
+
+    given(referenceRestTemplate
+        .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
+            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+        .willReturn(ResponseEntity.ok(response));
+
+    // When.
+    Map<String, Boolean> exists = referenceServiceImpl.rolesExist(codes, true);
+
+    // Then.
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    verify(referenceRestTemplate).exchange(
+        REFERENCE_URL + "/api/roles/exists/?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
+        HttpMethod.POST, requestEntity, responseType);
+  }
+
+  @Test
   public void shouldCheckAnyRolesMatchesWhenNotCurrentOnly() {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");

--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.27.2</version>
+  <version>3.28.0</version>
   <packaging>war</packaging>
 
   <prerequisites>
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-api</artifactId>
-      <version>2.10.1</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-api</artifactId>
-      <version>2.10.0</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>com.zaxxer</groupId>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -245,7 +245,7 @@ public class RoleResource {
   }
 
   /**
-   * EXISTS /roles/matches/ : check if there's a role in the database that matches the code
+   * POST /roles/matches/ : check if there's a role in the database that matches the code
    * provided, regardless of casing.
    *
    * @param codes            the codes of the RoleDTOs to check

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -220,7 +220,7 @@ public class RoleResource {
    * @return boolean true if exists otherwise false
    */
   @PostMapping("/roles/exists/")
-  public ResponseEntity<Map<String, Boolean>> rolesExist(@RequestBody List<String> codes,
+  public ResponseEntity<Map<String, String>> rolesExist(@RequestBody List<String> codes,
       @RequestParam(value = "columnFilters", required = false) String columnFilterJson)
       throws IOException {
     codes = codes.stream()
@@ -240,19 +240,12 @@ public class RoleResource {
     List<Role> roles = roleRepository.findAll(specs);
 
     Set<String> foundCodes = roles.stream().map(Role::getCode).collect(Collectors.toSet());
-    Map<String, Boolean> result = new HashMap<>();
 
-    codes.stream()
+    Map<String, String> result = codes.stream()
         .collect(Collectors.toMap(c -> c, c -> foundCodes.stream()
-            .anyMatch(fc -> fc.equalsIgnoreCase(c))))
-        .forEach((k, v) -> {
-          if (v && !foundCodes.contains(k)) {
-            result.put(foundCodes.stream().filter(fc -> fc.equalsIgnoreCase(k))
-                .collect(Collectors.toList()).get(0), true);
-          } else {
-            result.put(k, v);
-          }
-        });
+            .filter(fc -> fc.equalsIgnoreCase(c))
+            .findFirst()
+            .orElse("")));
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -213,7 +213,7 @@ public class RoleResource {
   }
 
   /**
-   * EXISTS /roles/exists/ : check if there's a role in the database that matches the code
+   * EXISTS /roles/matches/ : check if there's a role in the database that matches the code
    *     provided, regardless of casing.
    *
    * @param codes            the codes of the RoleDTOs to check
@@ -221,14 +221,14 @@ public class RoleResource {
    * @return Map             Where a key is the code to be matched, and a value is the code that
    *     was matched from the database.
    */
-  @PostMapping("/roles/exists/")
-  public ResponseEntity<Map<String, String>> rolesExist(@RequestBody List<String> codes,
+  @PostMapping("/roles/matches/")
+  public ResponseEntity<Map<String, String>> rolesMatch(@RequestBody List<String> codes,
       @RequestParam(value = "columnFilters", required = false) String columnFilterJson)
       throws IOException {
     codes = codes.stream()
         .map(code -> getConverter(code).decodeUrl().toString())
         .collect(Collectors.toList());
-    log.debug("REST request to check Roles exist: {}", codes);
+    log.debug("REST request to check Roles match: {}", codes);
     Specification<Role> specs = Specification.where(inIgnoreCase("code", new ArrayList<>(codes)));
 
     List<Class> filterEnumList = Lists.newArrayList(Status.class);

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -1,7 +1,6 @@
 package com.transformuk.hee.tis.reference.service.api;
 
 import static com.transformuk.hee.tis.reference.service.service.impl.SpecificationFactory.in;
-import static com.transformuk.hee.tis.reference.service.service.impl.SpecificationFactory.inIgnoreCase;
 import static uk.nhs.tis.StringConverter.getConverter;
 
 import com.google.common.collect.Lists;
@@ -262,7 +261,7 @@ public class RoleResource {
         .map(code -> getConverter(code).decodeUrl().toString())
         .collect(Collectors.toList());
     log.debug("REST request to check Roles match: {}", codes);
-    Specification<Role> specs = Specification.where(inIgnoreCase("code", new ArrayList<>(codes)));
+    Specification<Role> specs = Specification.where(in("code", new ArrayList<>(codes)));
 
     List<Class> filterEnumList = Lists.newArrayList(Status.class);
     List<ColumnFilter> columnFilters =

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -26,11 +26,11 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.apache.commons.lang3.StringUtils;
@@ -276,14 +276,18 @@ public class RoleResource {
 
     Set<String> foundCodes = roles.stream().map(Role::getCode).collect(Collectors.toSet());
 
+    // Filter out exact duplicates in codes
     Map<String, String> result = codes.stream()
         .collect(Collectors.toMap(c -> c, c -> foundCodes.stream()
             .filter(fc -> fc.equalsIgnoreCase(c))
             .findFirst()
             .orElse(""),
-            (c1,c2) -> c1));
+            (c1, c2) -> c1));
 
-    return new ResponseEntity<>(result, HttpStatus.OK);
+    // Filter out any other duplicate (e.g.: duplicates with different casing)
+    TreeMap<String, String> uniqueResults = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    uniqueResults.putAll(result);
+    return new ResponseEntity<>(uniqueResults, HttpStatus.OK);
   }
 
   /**

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -213,11 +213,13 @@ public class RoleResource {
   }
 
   /**
-   * EXISTS /roles/exists/ : check if roles exist (ignoring casing).
+   * EXISTS /roles/exists/ : check if there's a role in the database that matches the code
+   *     provided, regardless of casing.
    *
    * @param codes            the codes of the RoleDTOs to check
    * @param columnFilterJson The column filters to apply
-   * @return boolean true if exists otherwise false
+   * @return Map             Where a key is the code to be matched, and a value is the code that
+   *     was matched from the database.
    */
   @PostMapping("/roles/exists/")
   public ResponseEntity<Map<String, String>> rolesExist(@RequestBody List<String> codes,

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -279,7 +280,8 @@ public class RoleResource {
         .collect(Collectors.toMap(c -> c, c -> foundCodes.stream()
             .filter(fc -> fc.equalsIgnoreCase(c))
             .findFirst()
-            .orElse("")));
+            .orElse(""),
+            (c1,c2) -> c1));
 
     return new ResponseEntity<>(result, HttpStatus.OK);
   }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -82,7 +82,7 @@ public class RoleResource {
    *
    * @param roleDTO the roleDTO to create
    * @return the ResponseEntity with status 201 (Created) and with body the new roleDTO, or with
-   *     status 400 (Bad Request) if the role has already an ID
+   * status 400 (Bad Request) if the role has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/roles")
@@ -108,8 +108,8 @@ public class RoleResource {
    *
    * @param roleDTO the roleDTO to update
    * @return the ResponseEntity with status 200 (OK) and with body the updated roleDTO, or with
-   *     status 400 (Bad Request) if the roleDTO is not valid, or with status 500 (Internal Server
-   *     Error) if the roleDTO couldnt be updated
+   * status 400 (Bad Request) if the roleDTO is not valid, or with status 500 (Internal Server
+   * Error) if the roleDTO couldnt be updated
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/roles")
@@ -202,7 +202,7 @@ public class RoleResource {
    *
    * @param id the id of the roleDTO to retrieve
    * @return the ResponseEntity with status 200 (OK) and with body the roleDTO, or with status 404
-   *     (Not Found)
+   * (Not Found)
    */
   @GetMapping("/roles/{id}")
   public ResponseEntity<RoleDTO> getRole(@PathVariable Long id) {
@@ -242,12 +242,13 @@ public class RoleResource {
     Set<String> foundCodes = roles.stream().map(Role::getCode).collect(Collectors.toSet());
     Map<String, Boolean> result = new HashMap<>();
 
-        codes.stream()
-            .collect(Collectors.toMap(c -> c, c -> foundCodes.stream()
-                .anyMatch(fc -> fc.equalsIgnoreCase(c))))
-        .forEach((k,v) -> {
+    codes.stream()
+        .collect(Collectors.toMap(c -> c, c -> foundCodes.stream()
+            .anyMatch(fc -> fc.equalsIgnoreCase(c))))
+        .forEach((k, v) -> {
           if (v && !foundCodes.contains(k)) {
-            result.put(foundCodes.stream().filter(fc -> fc.equalsIgnoreCase(k)).collect(Collectors.toList()).get(0), v);
+            result.put(foundCodes.stream().filter(fc -> fc.equalsIgnoreCase(k))
+                .collect(Collectors.toList()).get(0), v);
           } else {
             result.put(k, v);
           }
@@ -277,7 +278,7 @@ public class RoleResource {
    *
    * @param roleDTOS List of the roleDTOS to create
    * @return the ResponseEntity with status 200 (Created) and with body the new roleDTOS, or with
-   *     status 400 (Bad Request) if the RoleDTO has already an ID
+   * status 400 (Bad Request) if the RoleDTO has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/bulk-roles")
@@ -308,8 +309,8 @@ public class RoleResource {
    *
    * @param roleDTOS List of the roleDTOS to update
    * @return the ResponseEntity with status 200 (OK) and with body the updated roleDTOS, or with
-   *     status 400 (Bad Request) if the roleDTOS is not valid, or with status 500 (Internal Server
-   *     Error) if the roleDTOS couldnt be updated
+   * status 400 (Bad Request) if the roleDTOS is not valid, or with status 500 (Internal Server
+   * Error) if the roleDTOS couldnt be updated
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/bulk-roles")
@@ -344,7 +345,7 @@ public class RoleResource {
    *
    * @param codes the codes to search by, using a ',' separator
    * @return the ResponseEntity with status 200 (OK) and with body the list of roleDTOs, or empty
-   *     list
+   * list
    */
   @GetMapping("/roles/in/{codes:.+}")
   public ResponseEntity<List<RoleDTO>> getRolesIn(@PathVariable String codes) {

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/RoleResource.java
@@ -82,7 +82,7 @@ public class RoleResource {
    *
    * @param roleDTO the roleDTO to create
    * @return the ResponseEntity with status 201 (Created) and with body the new roleDTO, or with
-   * status 400 (Bad Request) if the role has already an ID
+   *     status 400 (Bad Request) if the role has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/roles")
@@ -108,8 +108,8 @@ public class RoleResource {
    *
    * @param roleDTO the roleDTO to update
    * @return the ResponseEntity with status 200 (OK) and with body the updated roleDTO, or with
-   * status 400 (Bad Request) if the roleDTO is not valid, or with status 500 (Internal Server
-   * Error) if the roleDTO couldnt be updated
+   *     status 400 (Bad Request) if the roleDTO is not valid, or with status 500 (Internal Server
+   *     Error) if the roleDTO couldnt be updated
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/roles")
@@ -202,7 +202,7 @@ public class RoleResource {
    *
    * @param id the id of the roleDTO to retrieve
    * @return the ResponseEntity with status 200 (OK) and with body the roleDTO, or with status 404
-   * (Not Found)
+   *     (Not Found)
    */
   @GetMapping("/roles/{id}")
   public ResponseEntity<RoleDTO> getRole(@PathVariable Long id) {
@@ -213,7 +213,7 @@ public class RoleResource {
   }
 
   /**
-   * EXISTS /roles/exists/ : check if roles exist (ignore casing)
+   * EXISTS /roles/exists/ : check if roles exist (ignoring casing).
    *
    * @param codes            the codes of the RoleDTOs to check
    * @param columnFilterJson The column filters to apply
@@ -248,7 +248,7 @@ public class RoleResource {
         .forEach((k, v) -> {
           if (v && !foundCodes.contains(k)) {
             result.put(foundCodes.stream().filter(fc -> fc.equalsIgnoreCase(k))
-                .collect(Collectors.toList()).get(0), v);
+                .collect(Collectors.toList()).get(0), true);
           } else {
             result.put(k, v);
           }
@@ -278,7 +278,7 @@ public class RoleResource {
    *
    * @param roleDTOS List of the roleDTOS to create
    * @return the ResponseEntity with status 200 (Created) and with body the new roleDTOS, or with
-   * status 400 (Bad Request) if the RoleDTO has already an ID
+   *     status 400 (Bad Request) if the RoleDTO has already an ID
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PostMapping("/bulk-roles")
@@ -309,8 +309,8 @@ public class RoleResource {
    *
    * @param roleDTOS List of the roleDTOS to update
    * @return the ResponseEntity with status 200 (OK) and with body the updated roleDTOS, or with
-   * status 400 (Bad Request) if the roleDTOS is not valid, or with status 500 (Internal Server
-   * Error) if the roleDTOS couldnt be updated
+   *     status 400 (Bad Request) if the roleDTOS is not valid, or with status 500 (Internal Server
+   *     Error) if the roleDTOS couldnt be updated
    * @throws URISyntaxException if the Location URI syntax is incorrect
    */
   @PutMapping("/bulk-roles")
@@ -345,7 +345,7 @@ public class RoleResource {
    *
    * @param codes the codes to search by, using a ',' separator
    * @return the ResponseEntity with status 200 (OK) and with body the list of roleDTOs, or empty
-   * list
+   *     list
    */
   @GetMapping("/roles/in/{codes:.+}")
   public ResponseEntity<List<RoleDTO>> getRolesIn(@PathVariable String codes) {

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
@@ -86,34 +86,6 @@ public final class SpecificationFactory {
     };
   }
 
-  /**
-   * In condition for entity property, if property is from sub entity then it should contain '.' e.g
-   * sites.siteId, and is made specifically for strings where case is not relevant.
-   *
-   * @param attribute table name
-   * @param values values to be searched
-   * @return Specification
-   */
-  public static Specification inIgnoreCase(String attribute, Collection<String> values) {
-    return (root, query, cb) -> {
-      CriteriaBuilder.In cbi;
-      if (StringUtils.isNotEmpty(attribute) && attribute.contains(DOT)) {
-        // this support multiple entity in criteria e.g specialties.specialty.name or sites.siteId
-        String[] joinTable = StringUtils.split(attribute, DOT);
-        Join tableJoin = root.join(joinTable[0], JoinType.INNER);
-        for (int i = 1; i < joinTable.length - 1; i++) {
-          tableJoin = tableJoin.join(joinTable[i], JoinType.INNER);
-        }
-        cbi = cb.in(cb.upper(tableJoin.get(joinTable[joinTable.length - 1]))); // attribute
-      } else {
-        cbi = cb.in(cb.upper(root.get(attribute)));
-      }
-      values.forEach(v ->
-          cbi.value(v.toUpperCase()));
-      return cbi;
-    };
-  }
-
   public static Specification isBetween(String attribute, int min, int max) {
     return (root, query, cb) -> cb.between(root.get(attribute), min, max);
   }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
@@ -86,6 +86,27 @@ public final class SpecificationFactory {
     };
   }
 
+  public static Specification inIgnoreCase(String attribute, Collection<String> values) {
+    return (root, query, cb) -> {
+      CriteriaBuilder.In cbi;
+      if (StringUtils.isNotEmpty(attribute) && attribute.contains(DOT)) {
+        // this support multiple entity in criteria e.g specialties.specialty.name or sites.siteId
+        String[] joinTable = StringUtils.split(attribute, DOT);
+        Join tableJoin = root.join(joinTable[0], JoinType.INNER);
+        for (int i = 1; i < joinTable.length - 1; i++) {
+          tableJoin = tableJoin.join(joinTable[i], JoinType.INNER);
+        }
+        cbi = cb.in(cb.upper(tableJoin.get(joinTable[joinTable.length - 1]))); // attribute
+      } else {
+        cbi = cb.in(cb.upper(root.get(attribute)));
+      }
+      values.forEach(v -> {
+        cbi.value(v.toUpperCase());
+      });
+      return cbi;
+    };
+  }
+
   public static Specification isBetween(String attribute, int min, int max) {
     return (root, query, cb) -> cb.between(root.get(attribute), min, max);
   }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/SpecificationFactory.java
@@ -86,6 +86,14 @@ public final class SpecificationFactory {
     };
   }
 
+  /**
+   * In condition for entity property, if property is from sub entity then it should contain '.' e.g
+   * sites.siteId, and is made specifically for strings where case is not relevant.
+   *
+   * @param attribute table name
+   * @param values values to be searched
+   * @return Specification
+   */
   public static Specification inIgnoreCase(String attribute, Collection<String> values) {
     return (root, query, cb) -> {
       CriteriaBuilder.In cbi;
@@ -100,9 +108,8 @@ public final class SpecificationFactory {
       } else {
         cbi = cb.in(cb.upper(root.get(attribute)));
       }
-      values.forEach(v -> {
-        cbi.value(v.toUpperCase());
-      });
+      values.forEach(v ->
+          cbi.value(v.toUpperCase()));
       return cbi;
     };
   }

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.reference.api.dto.RoleDTO;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.Application;
@@ -23,6 +24,8 @@ import com.transformuk.hee.tis.reference.service.service.impl.RoleServiceImpl;
 import com.transformuk.hee.tis.reference.service.service.mapper.RoleMapper;
 import java.net.URLEncoder;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -417,6 +420,18 @@ public class RoleResourceIntTest {
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$." + code).value(""));
+  }
+
+  @Test
+  @Transactional
+  public void shouldReturnOneValueWhenDuplicateRolesArePassedIn() throws Exception {
+    roleRepository.saveAndFlush(role);
+
+    mockMvc.perform(post(MATCHES_ENDPOINT)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(TestUtil.convertObjectToJsonBytes(Arrays.asList(DEFAULT_CODE, DEFAULT_CODE))))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$." + DEFAULT_CODE).value(DEFAULT_CODE));
   }
 
   @Test

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
@@ -21,7 +21,6 @@ import com.transformuk.hee.tis.reference.service.repository.RoleCategoryReposito
 import com.transformuk.hee.tis.reference.service.repository.RoleRepository;
 import com.transformuk.hee.tis.reference.service.service.impl.RoleServiceImpl;
 import com.transformuk.hee.tis.reference.service.service.mapper.RoleMapper;
-import java.io.IOException;
 import java.net.URLEncoder;
 import java.time.LocalDate;
 import java.util.Collections;
@@ -373,7 +372,8 @@ public class RoleResourceIntTest {
 
     mockMvc.perform(post(EXISTS_ENDPOINT)
         .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(defaultCodeButDifferentCase))))
+        .content(TestUtil.convertObjectToJsonBytes(Collections.
+            singletonList(defaultCodeButDifferentCase))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
   }
@@ -433,7 +433,8 @@ public class RoleResourceIntTest {
 
     mockMvc.perform(post(EXISTS_ENDPOINT + "?columnFilters=" + columnFilter)
         .contentType(MediaType.APPLICATION_JSON)
-        .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(defaultCodeWithDifferentCase))))
+        .content(TestUtil.convertObjectToJsonBytes(Collections
+            .singletonList(defaultCodeWithDifferentCase))))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
   }
@@ -473,5 +474,4 @@ public class RoleResourceIntTest {
         .andExpect(jsonPath("$", hasSize(1)))
         .andExpect(jsonPath("$.[*].code").value(hasItem(code2)));
   }
-
 }

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
@@ -50,7 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(classes = Application.class)
 public class RoleResourceIntTest {
 
-  private static final String EXISTS_ENDPOINT = "/api/roles/exists/";
+  private static final String EXISTS_ENDPOINT = "/api/roles/matches/";
 
   private static final String DEFAULT_CODE = "AAAAAAAAAA";
   private static final String UPDATED_CODE = "BBBBBBBBBB";
@@ -341,7 +341,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnEmptyWhenNotExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotMatchesAndFilterNotApplied() throws Exception {
     String code = "notExists_" + LocalDate.now();
 
     mockMvc.perform(post(EXISTS_ENDPOINT)
@@ -353,7 +353,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnValueWhenExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnValueWhenMatchesAndFilterNotApplied() throws Exception {
     roleRepository.saveAndFlush(role);
 
     mockMvc.perform(post(EXISTS_ENDPOINT)
@@ -365,7 +365,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnValueWhenExistsWithDifferentCasingAndFilterNotApplied()
+  public void shouldReturnValueWhenMatchesWithDifferentCasingAndFilterNotApplied()
       throws Exception {
     roleRepository.saveAndFlush(role);
     String defaultCodeButDifferentCase = DEFAULT_CODE.toLowerCase();
@@ -380,7 +380,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnEmptyWhenNotExistsAndFilterApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotMatchesAndFilterApplied() throws Exception {
     String code = "notExists_" + LocalDate.now();
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
@@ -393,7 +393,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnEmptyWhenExistsAndFilterExcludes() throws Exception {
+  public void shouldReturnEmptyWhenMatchesAndFilterExcludes() throws Exception {
     role.setStatus(Status.INACTIVE);
     roleRepository.saveAndFlush(role);
 
@@ -408,7 +408,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnValueWhenExistsAndFilterIncludes() throws Exception {
+  public void shouldReturnValueWhenMatchesAndFilterIncludes() throws Exception {
     role.setStatus(Status.CURRENT);
     roleRepository.saveAndFlush(role);
 
@@ -423,7 +423,7 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnValueWhenExistsWithDifferentCasingAndFilterIncludes() throws Exception {
+  public void shouldReturnValueWhenMatchesWithDifferentCasingAndFilterIncludes() throws Exception {
     role.setStatus(Status.CURRENT);
     roleRepository.saveAndFlush(role);
 

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.reference.api.dto.RoleDTO;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.Application;
@@ -24,7 +23,6 @@ import com.transformuk.hee.tis.reference.service.service.impl.RoleServiceImpl;
 import com.transformuk.hee.tis.reference.service.service.mapper.RoleMapper;
 import java.net.URLEncoder;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/RoleResourceIntTest.java
@@ -341,31 +341,31 @@ public class RoleResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldReturnFalseWhenNotExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotExistsAndFilterNotApplied() throws Exception {
     String code = "notExists_" + LocalDate.now();
 
     mockMvc.perform(post(EXISTS_ENDPOINT)
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(false));
+        .andExpect(jsonPath("$." + code).value(""));
   }
 
   @Test
   @Transactional
-  public void shouldReturnTrueWhenExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnValueWhenExistsAndFilterNotApplied() throws Exception {
     roleRepository.saveAndFlush(role);
 
     mockMvc.perform(post(EXISTS_ENDPOINT)
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(DEFAULT_CODE))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
+        .andExpect(jsonPath("$." + DEFAULT_CODE).value(DEFAULT_CODE));
   }
 
   @Test
   @Transactional
-  public void shouldReturnTrueWhenExistsWithDifferentCasingAndFilterNotApplied()
+  public void shouldReturnValueWhenExistsWithDifferentCasingAndFilterNotApplied()
       throws Exception {
     roleRepository.saveAndFlush(role);
     String defaultCodeButDifferentCase = DEFAULT_CODE.toLowerCase();
@@ -375,12 +375,12 @@ public class RoleResourceIntTest {
         .content(TestUtil.convertObjectToJsonBytes(Collections.
             singletonList(defaultCodeButDifferentCase))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
+        .andExpect(jsonPath("$." + defaultCodeButDifferentCase).value(DEFAULT_CODE));
   }
 
   @Test
   @Transactional
-  public void shouldReturnFalseWhenNotExistsAndFilterApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotExistsAndFilterApplied() throws Exception {
     String code = "notExists_" + LocalDate.now();
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
@@ -388,12 +388,12 @@ public class RoleResourceIntTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(false));
+        .andExpect(jsonPath("$." + code).value(""));
   }
 
   @Test
   @Transactional
-  public void shouldReturnFalseWhenExistsAndFilterExcludes() throws Exception {
+  public void shouldReturnEmptyWhenExistsAndFilterExcludes() throws Exception {
     role.setStatus(Status.INACTIVE);
     roleRepository.saveAndFlush(role);
 
@@ -403,12 +403,12 @@ public class RoleResourceIntTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(DEFAULT_CODE))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + DEFAULT_CODE).value(false));
+        .andExpect(jsonPath("$." + DEFAULT_CODE).value(""));
   }
 
   @Test
   @Transactional
-  public void shouldReturnTrueWhenExistsAndFilterIncludes() throws Exception {
+  public void shouldReturnValueWhenExistsAndFilterIncludes() throws Exception {
     role.setStatus(Status.CURRENT);
     roleRepository.saveAndFlush(role);
 
@@ -418,12 +418,12 @@ public class RoleResourceIntTest {
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(DEFAULT_CODE))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
+        .andExpect(jsonPath("$." + DEFAULT_CODE).value(DEFAULT_CODE));
   }
 
   @Test
   @Transactional
-  public void shouldReturnTrueWhenExistsWithDifferentCasingAndFilterIncludes() throws Exception {
+  public void shouldReturnValueWhenExistsWithDifferentCasingAndFilterIncludes() throws Exception {
     role.setStatus(Status.CURRENT);
     roleRepository.saveAndFlush(role);
 
@@ -436,7 +436,7 @@ public class RoleResourceIntTest {
         .content(TestUtil.convertObjectToJsonBytes(Collections
             .singletonList(defaultCodeWithDifferentCase))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + DEFAULT_CODE).value(true));
+        .andExpect(jsonPath("$." + defaultCodeWithDifferentCase).value(DEFAULT_CODE));
   }
 
   @Test


### PR DESCRIPTION
**TIS21-1629**: Update bulk person create to validate and set the role correctly

Third approach. Rather than acting on TCS, the actual rolesExist endpoint in REFERENCE (RoleResource) gets changed.
It's supposed to work in a non case-sensitive way, so that roles (the codes of the roles) that exist (but with different casing) are returned in a Map as before. What is returned is a Map<String, String> where the key is the code that is passed in, and the value is the role as found in the database (correctly spelt), or an empty string if there are no matches.

This approach aims at disrupting TCS as least as possible. It'll still need to have PersonValidator changed in order to set the correctly spelt role code as the `PersonDto.role`, as per below:
```
TCS - PersonValidator.java

private List<FieldError> checkRole(PersonDTO personDto) {
    List<FieldError> fieldErrors = new ArrayList<>();

    String roleMultiValue = personDto.getRole();

    if (!StringUtils.isEmpty(roleMultiValue)) {
      // Bulk upload uses a ";" separator, account for both that and the default ",".
      List<String> roles = Arrays.stream(roleMultiValue.split("[;,]"))
          .map(String::trim)
          .collect(Collectors.toList());

      Map<String, String> rolesExist = referenceService.rolesExist(roles, true);
      List<String> correctedRoles = rolesExist.entrySet().stream()
          .map(entry -> entry.getValue().isEmpty() ? entry.getKey() : entry.getValue())
          .collect(Collectors.toList());

      personDto.setRole(String.join(",", correctedRoles));

      for (Entry<String, String> roleExists : rolesExist.entrySet()) {
        if (roleExists.getValue().isEmpty()) {
          fieldErrors.add(new FieldError(PERSON_DTO_NAME, "role",
              String.format("Role '%s' did not match a reference value.", roleExists.getKey())));
        }
      }
    }
```
Here's the TCS PR: [TCS PR 756](https://github.com/Health-Education-England/TIS-TCS/pull/756)

I tried to see if the `rolesExist` endpoint was being called from anywhere else where its slight change of behavior could determine undesired results, but I couldn't find any examples.
As far as I could tell, it seems to work fine locally when both tweaked versions of REFERENCE and TCS are running. Wrong codes get rejected, existing codes get accepted, codes that exist but with different casing get accepted and written with correct casing.