### PR TITLE
chore: fix task definition secret value key naming

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -11,47 +11,47 @@
         },
         {
           "name": "PROFILE_HOST",
-          "valuefrom": "profile-host-reference-${environment}"
+          "valueFrom": "profile-host-reference-${environment}"
         },
         {
           "name": "PROFILE_PORT",
-          "valuefrom": "profile-port-reference-${environment}"
+          "valueFrom": "profile-port-reference-${environment}"
         },
         {
           "name": "AUTH_HOST",
-          "valuefrom": "auth-host-reference-${environment}"
+          "valueFrom": "auth-host-reference-${environment}"
         },
         {
           "name": "AUTH_PORT",
-          "valuefrom": "auth-port-reference-${environment}"
+          "valueFrom": "auth-port-reference-${environment}"
         },
         {
           "name": "DBHOST",
-          "valuefrom": "dbhost-reference-${environment}"
+          "valueFrom": "dbhost-reference-${environment}"
         },
         {
           "name": "DBPORT",
-          "valuefrom": "dbport-reference-${environment}"
+          "valueFrom": "dbport-reference-${environment}"
         },
         {
           "name": "DBNAME",
-          "valuefrom": "dbname-reference-${environment}"
+          "valueFrom": "dbname-reference-${environment}"
         },
         {
           "name": "DBUSER",
-          "valuefrom": "dbuser-reference-${environment}"
+          "valueFrom": "dbuser-reference-${environment}"
         },
         {
           "name": "DBPASSWORD",
-          "valuefrom": "dbpassword-reference-${environment}"
+          "valueFrom": "dbpassword-reference-${environment}"
         },
         {
           "name": "USE_SSL",
-          "valuefrom": "use-ssl-reference-${environment}"
+          "valueFrom": "use-ssl-reference-${environment}"
         },
         {
           "name": "REFERENCE_CONTEXT_ROOT",
-          "valuefrom": "reference-context-root-reference-${environment}"
+          "valueFrom": "reference-context-root-reference-${environment}"
         },
         {
           "name": "LOG_DIR",


### PR DESCRIPTION
The `valueFrom` key is incorrect cased as `valuefrom`.

TIS21-2730