### PR TITLE
chore: add environment to task definition family

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -84,7 +84,7 @@
       ]
     }
   ],
-  "family": "tis-reference",
+  "family": "tis-reference-${environment}",
   "requiresCompatibilities": [
     "FARGATE"
   ],


### PR DESCRIPTION
All environments are using the same task family, so the revisions are a
mix of environments.
Fix this by adding the environment to the task family.

TIS21-SCOUT