### PR TITLE
fix:add distributionManagement in pom to specify the remote repositories

### DIFF
--- a/reference-api/pom.xml
+++ b/reference-api/pom.xml
@@ -58,4 +58,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -90,4 +90,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
The latest built referent-client.jar 4.12.2 can not be found in CodeArtifact.
https://eu-west-1.console.aws.amazon.com/codesuite/codeartifact/d/430723991443/hee/r/Health-Education-England/p/maven/com.transformuk.hee/reference-client/versions?region=eu-west-1&package-versions-meta=eyJmIjp7fSwicyI6e30sIm4iOjIwLCJpIjowfQ

TIS-SHED:no ticket