### PR TITLE
chore:remove unused stage flyway config

### DIFF
--- a/reference-service/src/main/resources/config/application-stage.yml
+++ b/reference-service/src/main/resources/config/application-stage.yml
@@ -6,7 +6,6 @@ spring:
   flyway:
     password: ${DBPASSWORD}
     schemas: ${DBNAME}
-    locations: classpath:db/migration/common,classpath:db/migration/tenant/hee,classpath:db/migration/stage
 
 logging:
   file: ${LOG_DIR}/reference.log


### PR DESCRIPTION
In 03/2023, we added a flyway script on Stage to revert changes for DBCs (#286) and later on the script was deleted.  

Today, noticed this Sentry error: https://health-education-england-9v.sentry.io/issues/4305107567/?alert_rule_id=13350173&alert_type=issue&project=6135905&referrer=slack, so raised this PR to remove the unused config.

no-ticket