### PR TITLE
fix:refactor leavingReason exist endpoint to match

### DIFF
--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-client</artifactId>
-  <version>4.13.0</version>
+  <version>4.14.0</version>
 
   <properties>
     <java.version>1.8</java.version>

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/ReferenceService.java
@@ -166,5 +166,5 @@ public interface ReferenceService extends ClientService {
 
   Map<String, Boolean> programmeMembershipTypesExist(List<String> codes, boolean currentOnly);
 
-  Map<String, Boolean> leavingReasonsExist(List<String> codes, boolean currentOnly);
+  Map<String, String> leavingReasonsMatch(List<String> codes, boolean currentOnly);
 }

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -96,7 +96,8 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   private static final String ROLES_MATCHING_MAPPINGS_ENDPOINT = "/api/roles/matches/";
   private static final String PROGRAMME_MEMBERSHIP_TYPES_MAPPINGS_ENDPOINT =
       "/api/programme-membership-types/exist";
-  private static final String LEAVING_REASONS_MAPPINGS_ENDPOINT = "/api/leaving-reasons/exist";
+  private static final String LEAVING_REASONS_MATCHING_MAPPINGS_ENDPOINT =
+      "/api/leaving-reasons/match";
   private static final String SITES_MAPPINGS_ENDPOINT = "/api/sites/exists/";
   private static final String SITES_IDS_MAPPINGS_ENDPOINT = "/api/sites/ids/exists/";
   private static final String TRUSTS_MAPPINGS_ENDPOINT = "/api/trusts/exists/";
@@ -636,13 +637,13 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
   }
 
   @Override
-  public Map<String, Boolean> leavingReasonsExist(List<String> codes, boolean currentOnly) {
-    String url = serviceUrl + LEAVING_REASONS_MAPPINGS_ENDPOINT;
+  public Map<String, String> leavingReasonsMatch(List<String> codes, boolean currentOnly) {
+    String url = serviceUrl + LEAVING_REASONS_MATCHING_MAPPINGS_ENDPOINT;
 
     if (currentOnly) {
       url += "?columnFilters=" + statusCurrentUrlEncoded;
     }
-    return valuesExists(url, codes);
+    return matchString(url, codes);
   }
 
   @Override

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -1575,25 +1575,25 @@ public class ReferenceServiceImplTest {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getMatchesStringReference();
 
-    Map<String, Boolean> response = new HashMap<>();
-    response.put("code1", true);
-    response.put("code2", false);
+    Map<String, String> response = new HashMap<>();
+    response.put("code1", "CODE1");
+    response.put("code2", "");
 
     given(referenceRestTemplate
         .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
-            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+            Matchers.<ParameterizedTypeReference<Map<String, String>>>any()))
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, Boolean> exists = referenceServiceImpl.leavingReasonsExist(codes, false);
+    Map<String, String> exists = referenceServiceImpl.leavingReasonsMatch(codes, false);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("CODE1"));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(""));
     verify(referenceRestTemplate)
-        .exchange(REFERENCE_URL + "/api/leaving-reasons/exist", HttpMethod.POST,
+        .exchange(REFERENCE_URL + "/api/leaving-reasons/match", HttpMethod.POST,
             requestEntity,
             responseType);
   }
@@ -1603,26 +1603,26 @@ public class ReferenceServiceImplTest {
     // Given.
     List<String> codes = Arrays.asList("code1", "code2");
     HttpEntity<List<String>> requestEntity = new HttpEntity<>(codes);
-    ParameterizedTypeReference<Map<String, Boolean>> responseType = getExistsStringReference();
+    ParameterizedTypeReference<Map<String, String>> responseType = getMatchesStringReference();
 
-    Map<String, Boolean> response = new HashMap<>();
-    response.put("code1", true);
-    response.put("code2", false);
+    Map<String, String> response = new HashMap<>();
+    response.put("code1", "CODE1");
+    response.put("code2", "CODE2");
 
     given(referenceRestTemplate
         .exchange(anyString(), any(HttpMethod.class), any(RequestEntity.class),
-            Matchers.<ParameterizedTypeReference<Map<String, Boolean>>>any()))
+            Matchers.<ParameterizedTypeReference<Map<String, String>>>any()))
         .willReturn(ResponseEntity.ok(response));
 
     // When.
-    Map<String, Boolean> exists = referenceServiceImpl.leavingReasonsExist(codes, true);
+    Map<String, String> exists = referenceServiceImpl.leavingReasonsMatch(codes, true);
 
     // Then.
-    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is(true));
-    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is(false));
+    assertThat("Unexpected 'exists' result value.", exists.get("code1"), is("CODE1"));
+    assertThat("Unexpected 'exists' result value.", exists.get("code2"), is("CODE2"));
     verify(referenceRestTemplate).exchange(
         REFERENCE_URL
-            + "/api/leaving-reasons/exist?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
+            + "/api/leaving-reasons/match?columnFilters=%7B%22status%22%3A%5B%22CURRENT%22%5D%7D",
         HttpMethod.POST, requestEntity, responseType);
   }
 }

--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.29.0</version>
+  <version>3.30.0</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/LeavingReasonService.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/LeavingReasonService.java
@@ -42,6 +42,15 @@ public interface LeavingReasonService {
   List<LeavingReasonDto> findAll(String searchQuery, List<ColumnFilter> columnFilters);
 
   /**
+   * Find LeavingReasons by codes, filtered by columnFilters (mainly status).
+   *
+   * @param codes         the codes to find.
+   * @param columnFilters The columns filters to apply.
+   * @return a list of found LeavingReasons as LeavingReasonDtos.
+   */
+  List<LeavingReasonDto> findCodes(List<String> codes, List<ColumnFilter> columnFilters);
+
+  /**
    * Delete the LeavingReason with the given ID.
    *
    * @param id The ID of the LeavingReason to delete.

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/LeavingReasonServiceImpl.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/LeavingReasonServiceImpl.java
@@ -84,6 +84,25 @@ public class LeavingReasonServiceImpl implements LeavingReasonService {
     return mapper.leavingReasonsToLeavingReasonDtos(result);
   }
 
+  /**
+   * Find LeavingReasons by codes, filtered by columnFilters (mainly status).
+   *
+   * @param codes         the codes to find.
+   * @param columnFilters The columns filters to apply.
+   * @return a list of found LeavingReasons as LeavingReasonDtos.
+   */
+  @Override
+  public List<LeavingReasonDto> findCodes(List<String> codes, List<ColumnFilter> columnFilters) {
+    Specification<LeavingReason> specs = Specification.where(in("code", new ArrayList<>(codes)));
+
+    for (ColumnFilter columnFilter : columnFilters) {
+      specs = specs.and(in(columnFilter.getName(), columnFilter.getValues()));
+    }
+
+    List<LeavingReason> leavingReasons = repository.findAll(specs);
+    return mapper.leavingReasonsToLeavingReasonDtos(leavingReasons);
+  }
+
   @Override
   public void delete(Long id) {
     LOGGER.debug("Request to delete leaving reason with id {}.", id);

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LeavingReasonResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LeavingReasonResourceIntTest.java
@@ -598,7 +598,7 @@ public class LeavingReasonResourceIntTest {
   }
 
   @Test
-  public void shouldReturnFalseWhenNotExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotExistsAndFilterNotApplied() throws Exception {
     String code = "notExists";
 
     mockMvc.perform(post(MATCH_ENDPOINT)
@@ -609,7 +609,7 @@ public class LeavingReasonResourceIntTest {
   }
 
   @Test
-  public void shouldReturnTrueWhenExistsAndFilterNotApplied() throws Exception {
+  public void shouldReturnCodesFromDbWhenExistsAndFilterNotApplied() throws Exception {
     final String code2 = "CODE2";
     final String code2LowerCase = code2.toLowerCase();
     LeavingReason leavingReason1 = createLeavingReason(CODE1, "label1", Status.CURRENT);
@@ -626,7 +626,7 @@ public class LeavingReasonResourceIntTest {
   }
 
   @Test
-  public void shouldReturnFalseWhenNotExistsAndFilterApplied() throws Exception {
+  public void shouldReturnEmptyWhenNotExistsAndFilterApplied() throws Exception {
     final String code = "notExists";
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
@@ -639,7 +639,7 @@ public class LeavingReasonResourceIntTest {
   }
 
   @Test
-  public void shouldReturnFalseWhenExistsAndFilterExcludes() throws Exception {
+  public void shouldReturnEmptyWhenExistsAndFilterExcludes() throws Exception {
     LeavingReason leavingReason = createLeavingReason(CODE1, "label1", Status.INACTIVE);
     repository.save(leavingReason);
 
@@ -653,7 +653,7 @@ public class LeavingReasonResourceIntTest {
   }
 
   @Test
-  public void shouldReturnTrueWhenExistsAndFilterIncludes() throws Exception {
+  public void shouldReturnCodeWhenExistsAndFilterIncludes() throws Exception {
     LeavingReason leavingReason = createLeavingReason(CODE1, "label1", Status.CURRENT);
 
     repository.save(leavingReason);

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LeavingReasonResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LeavingReasonResourceIntTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.reference.api.dto.LeavingReasonDto;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.Application;
@@ -41,9 +42,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = Application.class)
 @Transactional
-public class LeavingReasonResourceIntegrationTest {
+public class LeavingReasonResourceIntTest {
 
-  private static final String EXISTS_ENDPOINT = "/api/leaving-reasons/exist/";
+  private static final String MATCH_ENDPOINT = "/api/leaving-reasons/match/";
+  private static final String CODE1 = "code1";
 
   @Autowired
   private LeavingReasonRepository repository;
@@ -599,67 +601,69 @@ public class LeavingReasonResourceIntegrationTest {
   public void shouldReturnFalseWhenNotExistsAndFilterNotApplied() throws Exception {
     String code = "notExists";
 
-    mockMvc.perform(post(EXISTS_ENDPOINT)
+    mockMvc.perform(post(MATCH_ENDPOINT)
         .contentType(MediaType.APPLICATION_JSON)
         .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(false));
+        .andExpect(jsonPath("$." + code).value(""));
   }
 
   @Test
   public void shouldReturnTrueWhenExistsAndFilterNotApplied() throws Exception {
-    String code = "code1";
-    LeavingReason leavingReason = createLeavingReason(code, "label1", Status.CURRENT);
-    repository.save(leavingReason);
+    final String code2 = "CODE2";
+    final String code2LowerCase = code2.toLowerCase();
+    LeavingReason leavingReason1 = createLeavingReason(CODE1, "label1", Status.CURRENT);
+    LeavingReason leavingReason2 = createLeavingReason(code2, "label2", Status.CURRENT);
+    repository.save(leavingReason1);
+    repository.save(leavingReason2);
 
-    mockMvc.perform(post(EXISTS_ENDPOINT)
+    mockMvc.perform(post(MATCH_ENDPOINT)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
-        .andDo(print())
+            .content(TestUtil.convertObjectToJsonBytes(Lists.newArrayList(CODE1, code2LowerCase))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(true));
+        .andExpect(jsonPath("$." + CODE1).value(CODE1))
+        .andExpect(jsonPath("$." + code2LowerCase).value(code2));
   }
 
   @Test
   public void shouldReturnFalseWhenNotExistsAndFilterApplied() throws Exception {
-    String code = "notExists";
+    final String code = "notExists";
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
-    mockMvc.perform(post(EXISTS_ENDPOINT + "?columnFilters=" + columnFilter)
+    mockMvc.perform(post(MATCH_ENDPOINT + "?columnFilters=" + columnFilter)
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
+        .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(false));
+        .andExpect(jsonPath("$." + code).value(""));
   }
 
   @Test
   public void shouldReturnFalseWhenExistsAndFilterExcludes() throws Exception {
-    String code = "code1";
-    LeavingReason leavingReason = createLeavingReason(code, "label1", Status.INACTIVE);
+    LeavingReason leavingReason = createLeavingReason(CODE1, "label1", Status.INACTIVE);
     repository.save(leavingReason);
 
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
-    mockMvc.perform(post(EXISTS_ENDPOINT + "?columnFilters=" + columnFilter)
+    mockMvc.perform(post(MATCH_ENDPOINT + "?columnFilters=" + columnFilter)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
+            .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(CODE1))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(false));
+        .andExpect(jsonPath("$." + CODE1).value(""));
   }
 
   @Test
   public void shouldReturnTrueWhenExistsAndFilterIncludes() throws Exception {
-    String code = "code1";
-    LeavingReason leavingReason = createLeavingReason(code, "label1", Status.CURRENT);
+    LeavingReason leavingReason = createLeavingReason(CODE1, "label1", Status.CURRENT);
 
     repository.save(leavingReason);
 
     String columnFilter = URLEncoder.encode("{\"status\":[\"CURRENT\"]}", CharEncoding.UTF_8);
 
-    mockMvc.perform(post(EXISTS_ENDPOINT + "?columnFilters=" + columnFilter)
+    mockMvc.perform(post(MATCH_ENDPOINT + "?columnFilters=" + columnFilter)
             .contentType(MediaType.APPLICATION_JSON)
-            .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(code))))
+            .content(TestUtil.convertObjectToJsonBytes(Collections.singletonList(CODE1))))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$." + code).value(true));
+        .andExpect(jsonPath("$." + CODE1).value(CODE1));
   }
 }


### PR DESCRIPTION
In the previous PR, I added an endpoint `/leaving-reasons/exist` to check if the list of leaving reasons exist in Reference data. 
However, if the leaving reason String casing is not exactly the same as Reference data, it returns a `false` boolean. So here I want to change the endpoint to `/leaving-reasons/match` and it returns the exact Reference value even if the casing is different.

TIS21-3785