### PR TITLE
fix:fundingType Save error

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.31.0</version>
+  <version>3.31.1</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
@@ -51,7 +51,7 @@ public class FundingType implements Serializable {
   private boolean allowDetails;
 
   @OneToMany(mappedBy = "fundingType", orphanRemoval = true, cascade = CascadeType.ALL)
-  private Set<FundingSubType> fundingSubTypes = new HashSet();
+  private Set<FundingSubType> fundingSubTypes = new HashSet<>();
 
   @Override
   public boolean equals(Object o) {

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/model/FundingType.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.reference.service.model;
 
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -50,7 +51,7 @@ public class FundingType implements Serializable {
   private boolean allowDetails;
 
   @OneToMany(mappedBy = "fundingType", orphanRemoval = true, cascade = CascadeType.ALL)
-  private Set<FundingSubType> fundingSubTypes;
+  private Set<FundingSubType> fundingSubTypes = new HashSet();
 
   @Override
   public boolean equals(Object o) {


### PR DESCRIPTION
This is caused by adding the new feature of FundingSubType. 
An error "Hibernate - A collection with cascade=”all-delete-orphan” was no longer referenced by the owning entity instance" was thrown.

TIS21-5380