### PR TITLE
feat:add api to get all subTypes for a fundingType

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.32.0</version>
+  <version>3.33.0</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResource.java
@@ -59,8 +59,8 @@ public class FundingSubTypeResource {
   /**
    * Constructor for FundingSubTypeResource.
    *
-   * @param fundingSubTypeMapper the mapper to convert between entity and dto
-   * @param fundingSubTypeService the service to handle business logic
+   * @param fundingSubTypeMapper    the mapper to convert between entity and dto
+   * @param fundingSubTypeService   the service to handle business logic
    * @param fundingSubTypeValidator the validator to validate user data
    */
   public FundingSubTypeResource(FundingSubTypeMapper fundingSubTypeMapper,
@@ -192,5 +192,21 @@ public class FundingSubTypeResource {
     HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page,
         "/api/funding-sub-types");
     return new ResponseEntity<>(results.getContent(), headers, HttpStatus.OK);
+  }
+
+  /**
+   * Get all fundingSubTypes for a fundingType.
+   *
+   * @param fundingTypeId the id of the fundingType to search
+   * @return a list of fundingSubType for the fundingType searched for
+   */
+  @GetMapping("/funding-types/{fundingTypeId}/funding-sub-types")
+  public ResponseEntity<List<FundingSubTypeDto>> getFundingSubTypesForFundingType(
+      @PathVariable Long fundingTypeId) {
+    log.debug("REST request to get all sub types for a funding type");
+    List<FundingSubType> fundingSubTypes = fundingSubTypeService.findSubTypesForFundingTypeId(
+        fundingTypeId);
+    List<FundingSubTypeDto> fundingSubTypeDtos = fundingSubTypeMapper.toDtos(fundingSubTypes);
+    return ResponseEntity.ok(fundingSubTypeDtos);
   }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResource.java
@@ -193,20 +193,4 @@ public class FundingSubTypeResource {
         "/api/funding-sub-types");
     return new ResponseEntity<>(results.getContent(), headers, HttpStatus.OK);
   }
-
-  /**
-   * Get all fundingSubTypes for a fundingType.
-   *
-   * @param fundingTypeId the id of the fundingType to search
-   * @return a list of fundingSubType for the fundingType searched for
-   */
-  @GetMapping("/funding-types/{fundingTypeId}/funding-sub-types")
-  public ResponseEntity<List<FundingSubTypeDto>> getFundingSubTypesForFundingType(
-      @PathVariable Long fundingTypeId) {
-    log.debug("REST request to get all sub types for a funding type");
-    List<FundingSubType> fundingSubTypes = fundingSubTypeService.findSubTypesForFundingTypeId(
-        fundingTypeId);
-    List<FundingSubTypeDto> fundingSubTypeDtos = fundingSubTypeMapper.toDtos(fundingSubTypes);
-    return ResponseEntity.ok(fundingSubTypeDtos);
-  }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
@@ -1,15 +1,19 @@
 package com.transformuk.hee.tis.reference.service.api;
 
 import com.google.common.collect.Lists;
+import com.transformuk.hee.tis.reference.api.dto.FundingSubTypeDto;
 import com.transformuk.hee.tis.reference.api.dto.FundingTypeDTO;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.api.util.ColumnFilterUtil;
 import com.transformuk.hee.tis.reference.service.api.util.HeaderUtil;
 import com.transformuk.hee.tis.reference.service.api.util.PaginationUtil;
 import com.transformuk.hee.tis.reference.service.model.ColumnFilter;
+import com.transformuk.hee.tis.reference.service.model.FundingSubType;
 import com.transformuk.hee.tis.reference.service.model.FundingType;
 import com.transformuk.hee.tis.reference.service.repository.FundingTypeRepository;
+import com.transformuk.hee.tis.reference.service.service.impl.FundingSubTypeServiceImpl;
 import com.transformuk.hee.tis.reference.service.service.impl.FundingTypeServiceImpl;
+import com.transformuk.hee.tis.reference.service.service.mapper.FundingSubTypeMapper;
 import com.transformuk.hee.tis.reference.service.service.mapper.FundingTypeMapper;
 import io.github.jhipster.web.util.ResponseUtil;
 import io.jsonwebtoken.lang.Collections;
@@ -57,13 +61,19 @@ public class FundingTypeResource {
   private final FundingTypeRepository fundingTypeRepository;
   private final FundingTypeMapper fundingTypeMapper;
   private final FundingTypeServiceImpl fundingTypeService;
+  private final FundingSubTypeServiceImpl fundingSubTypeService;
+  private final FundingSubTypeMapper fundingSubTypeMapper;
 
   public FundingTypeResource(FundingTypeRepository fundingTypeRepository,
       FundingTypeMapper fundingTypeMapper,
-      FundingTypeServiceImpl fundingTypeService) {
+      FundingTypeServiceImpl fundingTypeService,
+      FundingSubTypeServiceImpl fundingSubTypeService,
+      FundingSubTypeMapper fundingSubTypeMapper) {
     this.fundingTypeRepository = fundingTypeRepository;
     this.fundingTypeMapper = fundingTypeMapper;
     this.fundingTypeService = fundingTypeService;
+    this.fundingSubTypeService = fundingSubTypeService;
+    this.fundingSubTypeMapper = fundingSubTypeMapper;
   }
 
   /**
@@ -251,5 +261,21 @@ public class FundingTypeResource {
     List<FundingTypeDTO> results = fundingTypeMapper.fundingTypesToFundingTypeDTOs(fundingTypes);
     return ResponseEntity.ok()
         .body(results);
+  }
+
+  /**
+   * Get all fundingSubTypes for a fundingType.
+   *
+   * @param fundingTypeId the id of the fundingType to search
+   * @return a list of fundingSubType for the fundingType searched for
+   */
+  @GetMapping("/funding-types/{fundingTypeId}/funding-sub-types")
+  public ResponseEntity<List<FundingSubTypeDto>> getFundingSubTypesForFundingType(
+      @PathVariable Long fundingTypeId) {
+    log.debug("REST request to get all sub types for a funding type");
+    List<FundingSubType> fundingSubTypes = fundingSubTypeService.findSubTypesForFundingTypeId(
+        fundingTypeId);
+    List<FundingSubTypeDto> fundingSubTypeDtos = fundingSubTypeMapper.toDtos(fundingSubTypes);
+    return ResponseEntity.ok(fundingSubTypeDtos);
   }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResource.java
@@ -264,17 +264,17 @@ public class FundingTypeResource {
   }
 
   /**
-   * Get all fundingSubTypes for a fundingType.
+   * Get all current fundingSubTypes for a fundingType.
    *
    * @param fundingTypeId the id of the fundingType to search
    * @return a list of fundingSubType for the fundingType searched for
    */
   @GetMapping("/funding-types/{fundingTypeId}/funding-sub-types")
-  public ResponseEntity<List<FundingSubTypeDto>> getFundingSubTypesForFundingType(
+  public ResponseEntity<List<FundingSubTypeDto>> getCurrentFundingSubTypesForFundingType(
       @PathVariable Long fundingTypeId) {
     log.debug("REST request to get all sub types for a funding type");
-    List<FundingSubType> fundingSubTypes = fundingSubTypeService.findSubTypesForFundingTypeId(
-        fundingTypeId);
+    List<FundingSubType> fundingSubTypes =
+        fundingSubTypeService.findCurrentSubTypesForFundingTypeId(fundingTypeId);
     List<FundingSubTypeDto> fundingSubTypeDtos = fundingSubTypeMapper.toDtos(fundingSubTypes);
     return ResponseEntity.ok(fundingSubTypeDtos);
   }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/FundingSubTypeRepository.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/FundingSubTypeRepository.java
@@ -1,8 +1,7 @@
 package com.transformuk.hee.tis.reference.service.repository;
 
 import com.transformuk.hee.tis.reference.service.model.FundingSubType;
-import com.transformuk.hee.tis.reference.service.model.FundingType;
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -13,4 +12,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 @SuppressWarnings("unused")
 public interface FundingSubTypeRepository extends JpaRepository<FundingSubType, UUID>,
     JpaSpecificationExecutor<FundingSubType> {
+
+  List<FundingSubType> findAllByFundingTypeId(Long fundingTypeId);
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/FundingSubTypeRepository.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/FundingSubTypeRepository.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.reference.service.repository;
 
+import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.model.FundingSubType;
 import java.util.List;
 import java.util.UUID;
@@ -13,5 +14,5 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 public interface FundingSubTypeRepository extends JpaRepository<FundingSubType, UUID>,
     JpaSpecificationExecutor<FundingSubType> {
 
-  List<FundingSubType> findAllByFundingTypeId(Long fundingTypeId);
+  List<FundingSubType> findByStatusAndFundingTypeId(Status status, Long fundingTypeId);
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/FundingSubTypeServiceImpl.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/FundingSubTypeServiceImpl.java
@@ -36,4 +36,8 @@ public class FundingSubTypeServiceImpl extends AbstractReferenceService<FundingS
   protected JpaSpecificationExecutor<FundingSubType> getSpecificationExecutor() {
     return repository;
   }
+
+  public List<FundingSubType> findSubTypesForFundingTypeId(Long fundingTypeId) {
+    return repository.findAllByFundingTypeId(fundingTypeId);
+  }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/FundingSubTypeServiceImpl.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/impl/FundingSubTypeServiceImpl.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.reference.service.service.impl;
 
+import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.model.FundingSubType;
 import com.transformuk.hee.tis.reference.service.repository.FundingSubTypeRepository;
 import com.transformuk.hee.tis.reference.service.service.AbstractReferenceService;
@@ -37,7 +38,7 @@ public class FundingSubTypeServiceImpl extends AbstractReferenceService<FundingS
     return repository;
   }
 
-  public List<FundingSubType> findSubTypesForFundingTypeId(Long fundingTypeId) {
-    return repository.findAllByFundingTypeId(fundingTypeId);
+  public List<FundingSubType> findCurrentSubTypesForFundingTypeId(Long fundingTypeId) {
+    return repository.findByStatusAndFundingTypeId(Status.CURRENT, fundingTypeId);
   }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/mapper/FundingSubTypeMapper.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/service/mapper/FundingSubTypeMapper.java
@@ -2,6 +2,7 @@ package com.transformuk.hee.tis.reference.service.service.mapper;
 
 import com.transformuk.hee.tis.reference.api.dto.FundingSubTypeDto;
 import com.transformuk.hee.tis.reference.service.model.FundingSubType;
+import java.util.List;
 import org.mapstruct.Mapper;
 
 /**
@@ -13,4 +14,6 @@ public interface FundingSubTypeMapper {
   FundingSubTypeDto toDto(FundingSubType fundingSubType);
 
   FundingSubType toEntity(FundingSubTypeDto fundingSubTypeDto);
+
+  List<FundingSubTypeDto> toDtos(List<FundingSubType> fundingTypeList);
 }

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingSubTypeResourceIntTest.java
@@ -1,7 +1,6 @@
 package com.transformuk.hee.tis.reference.service.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -261,26 +260,5 @@ class FundingSubTypeResourceIntTest {
   void getNonExistingFundingSubType() throws Exception {
     restFundingSubTypeMockMvc.perform(get("/api/funding-sub-types/{id}", UUID.randomUUID()))
         .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @Transactional
-  void getFundingSubTypesForFundingType() throws Exception {
-    FundingSubType fundingSubType1 = new FundingSubType();
-    fundingSubType1.setCode(UPDATED_CODE);
-    fundingSubType1.setLabel(UPDATED_LABEL);
-    fundingSubType1.setStatus(Status.CURRENT);
-    FundingType fundingType = fundingSubType.getFundingType();
-    fundingSubType1.setFundingType(fundingType);
-
-    fundingSubTypeRepository.saveAllAndFlush(Arrays.asList(fundingSubType, fundingSubType1));
-
-    restFundingSubTypeMockMvc.perform(
-            get("/api/funding-types/{id}/funding-sub-types", fundingType.getId()))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-        .andExpect(jsonPath("$.length()").value(equalTo(2)))
-        .andExpect(jsonPath("$.[0].fundingType.id").value(fundingType.getId().intValue()))
-        .andExpect(jsonPath("$.[1].fundingType.id").value(fundingType.getId().intValue()));
   }
 }

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/FundingTypeResourceIntTest.java
@@ -51,10 +51,12 @@ public class FundingTypeResourceIntTest {
 
   private static final String DEFAULT_CODE = "AAAAAAAAAA";
   private static final String UPDATED_CODE = "BBBBBBBBBB";
+  private static final String INACTIVE_CODE = "CCCCCCCCCC";
   private static final String UNENCODED_CODE = "Te$t Code";
 
   private static final String DEFAULT_LABEL = "AAAAAAAAAA";
   private static final String UPDATED_LABEL = "BBBBBBBBBB";
+  private static final String INACTIVE_LABEL = "CCCCCCCCCC";
   private static final String UNENCODED_LABEL = "Te$t Label";
 
   @Autowired
@@ -365,20 +367,27 @@ public class FundingTypeResourceIntTest {
   @Test
   @Transactional
   public void getFundingSubTypesForFundingType() throws Exception {
-    fundingTypeRepository.saveAndFlush(fundingType);
+    fundingType = fundingTypeRepository.saveAndFlush(fundingType);
+
     FundingSubType fundingSubType = new FundingSubType();
     fundingSubType.setCode(DEFAULT_CODE);
     fundingSubType.setLabel(DEFAULT_LABEL);
     fundingSubType.setStatus(Status.CURRENT);
     fundingSubType.setFundingType(fundingType);
+
     FundingSubType fundingSubType1 = new FundingSubType();
     fundingSubType1.setCode(UPDATED_CODE);
     fundingSubType1.setLabel(UPDATED_LABEL);
     fundingSubType1.setStatus(Status.CURRENT);
-    FundingType fundingType = fundingSubType.getFundingType();
     fundingSubType1.setFundingType(fundingType);
 
-    fundingSubTypeRepository.saveAllAndFlush(Arrays.asList(fundingSubType, fundingSubType1));
+    FundingSubType fundingSubType2 = new FundingSubType();
+    fundingSubType2.setCode(INACTIVE_CODE);
+    fundingSubType2.setLabel(INACTIVE_LABEL);
+    fundingSubType2.setStatus(Status.INACTIVE);
+    fundingSubType2.setFundingType(fundingType);
+
+    fundingSubTypeRepository.saveAllAndFlush(Arrays.asList(fundingSubType, fundingSubType1, fundingSubType2));
 
     restFundingTypeMockMvc.perform(
             get("/api/funding-types/{id}/funding-sub-types", fundingType.getId()))

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/service/mapper/FundingSubTypeMapperTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/service/mapper/FundingSubTypeMapperTest.java
@@ -1,12 +1,15 @@
 package com.transformuk.hee.tis.reference.service.service.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.transformuk.hee.tis.reference.api.dto.FundingSubTypeDto;
 import com.transformuk.hee.tis.reference.api.dto.FundingTypeDTO;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.service.model.FundingSubType;
 import com.transformuk.hee.tis.reference.service.model.FundingType;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,9 +17,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 class FundingSubTypeMapperTest {
 
-  private static final String FUNDING_SUB_TYPE_LABEL = "label";
-  private static final String FUNDING_SUB_TYPE_CODE = "code";
-  private static final UUID FUNDING_SUB_TYPE_UUID = UUID.randomUUID();
+  private static final String FUNDING_SUB_TYPE_LABEL_1 = "label1";
+  private static final String FUNDING_SUB_TYPE_CODE_1 = "code";
+  private static final UUID FUNDING_SUB_TYPE_UUID_1 = UUID.randomUUID();
+  private static final String FUNDING_SUB_TYPE_LABEL_2 = "label2";
+  private static final String FUNDING_SUB_TYPE_CODE_2 = "code2";
+  private static final UUID FUNDING_SUB_TYPE_UUID_2 = UUID.randomUUID();
   private static final Long FUNDING_TYPE_ID = 1L;
 
   FundingSubTypeMapper mapper;
@@ -34,16 +40,16 @@ class FundingSubTypeMapperTest {
     fundingType.setStatus(Status.CURRENT);
     FundingSubType fundingSubType = new FundingSubType();
     fundingSubType.setFundingType(fundingType);
-    fundingSubType.setLabel(FUNDING_SUB_TYPE_LABEL);
-    fundingSubType.setCode(FUNDING_SUB_TYPE_CODE);
-    fundingSubType.setId(FUNDING_SUB_TYPE_UUID);
+    fundingSubType.setLabel(FUNDING_SUB_TYPE_LABEL_1);
+    fundingSubType.setCode(FUNDING_SUB_TYPE_CODE_1);
+    fundingSubType.setId(FUNDING_SUB_TYPE_UUID_1);
     fundingSubType.setStatus(Status.CURRENT);
 
     FundingSubTypeDto fundingSubTypeDto = mapper.toDto(fundingSubType);
 
-    assertEquals(FUNDING_SUB_TYPE_LABEL, fundingSubTypeDto.getLabel());
-    assertEquals(FUNDING_SUB_TYPE_CODE, fundingSubTypeDto.getCode());
-    assertEquals(FUNDING_SUB_TYPE_UUID, fundingSubTypeDto.getId());
+    assertEquals(FUNDING_SUB_TYPE_LABEL_1, fundingSubTypeDto.getLabel());
+    assertEquals(FUNDING_SUB_TYPE_CODE_1, fundingSubTypeDto.getCode());
+    assertEquals(FUNDING_SUB_TYPE_UUID_1, fundingSubTypeDto.getId());
     assertEquals(Status.CURRENT, fundingSubTypeDto.getStatus());
     assertEquals(FUNDING_TYPE_ID, fundingSubTypeDto.getFundingType().getId());
   }
@@ -55,17 +61,49 @@ class FundingSubTypeMapperTest {
     fundingTypeDto.setStatus(Status.CURRENT);
     FundingSubTypeDto fundingSubTypeDto = new FundingSubTypeDto();
     fundingSubTypeDto.setFundingType(fundingTypeDto);
-    fundingSubTypeDto.setLabel(FUNDING_SUB_TYPE_LABEL);
-    fundingSubTypeDto.setCode(FUNDING_SUB_TYPE_CODE);
-    fundingSubTypeDto.setId(FUNDING_SUB_TYPE_UUID);
+    fundingSubTypeDto.setLabel(FUNDING_SUB_TYPE_LABEL_1);
+    fundingSubTypeDto.setCode(FUNDING_SUB_TYPE_CODE_1);
+    fundingSubTypeDto.setId(FUNDING_SUB_TYPE_UUID_1);
     fundingSubTypeDto.setStatus(Status.CURRENT);
 
     FundingSubType fundingSubType = mapper.toEntity(fundingSubTypeDto);
 
-    assertEquals(FUNDING_SUB_TYPE_LABEL, fundingSubType.getLabel());
-    assertEquals(FUNDING_SUB_TYPE_CODE, fundingSubType.getCode());
-    assertEquals(FUNDING_SUB_TYPE_UUID, fundingSubType.getId());
+    assertEquals(FUNDING_SUB_TYPE_LABEL_1, fundingSubType.getLabel());
+    assertEquals(FUNDING_SUB_TYPE_CODE_1, fundingSubType.getCode());
+    assertEquals(FUNDING_SUB_TYPE_UUID_1, fundingSubType.getId());
     assertEquals(Status.CURRENT, fundingSubType.getStatus());
     assertEquals(FUNDING_TYPE_ID, fundingSubType.getFundingType().getId());
+  }
+
+  @Test
+  void fundingSubTypeToDtos() {
+    FundingType fundingType = new FundingType();
+    fundingType.setId(FUNDING_TYPE_ID);
+    fundingType.setStatus(Status.CURRENT);
+
+    FundingSubType fundingSubType1 = new FundingSubType();
+    fundingSubType1.setFundingType(fundingType);
+    fundingSubType1.setLabel(FUNDING_SUB_TYPE_LABEL_1);
+    fundingSubType1.setCode(FUNDING_SUB_TYPE_CODE_1);
+    fundingSubType1.setId(FUNDING_SUB_TYPE_UUID_1);
+    fundingSubType1.setStatus(Status.CURRENT);
+
+    FundingSubType fundingSubType2 = new FundingSubType();
+    fundingSubType2.setFundingType(fundingType);
+    fundingSubType2.setLabel(FUNDING_SUB_TYPE_LABEL_2);
+    fundingSubType2.setCode(FUNDING_SUB_TYPE_CODE_2);
+    fundingSubType2.setId(FUNDING_SUB_TYPE_UUID_2);
+    fundingSubType2.setStatus(Status.CURRENT);
+
+    List<FundingSubTypeDto> fundingSubTypeDtos = mapper.toDtos(
+        Arrays.asList(fundingSubType1, fundingSubType2));
+
+    assertEquals(2, fundingSubTypeDtos.size());
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getId().equals(FUNDING_SUB_TYPE_UUID_1)));
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getId().equals(FUNDING_SUB_TYPE_UUID_2)));
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getLabel().equals(FUNDING_SUB_TYPE_LABEL_1)));
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getLabel().equals(FUNDING_SUB_TYPE_LABEL_2)));
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getCode().equals(FUNDING_SUB_TYPE_CODE_1)));
+    assertTrue(fundingSubTypeDtos.stream().anyMatch(e -> e.getCode().equals(FUNDING_SUB_TYPE_CODE_2)));
   }
 }


### PR DESCRIPTION
This PR will add a new endpoint (""/funding-types/{fundingTypeId}/funding-sub-types"") to get all FundingSubTypes for a FundingType id.

I tried setting `FundingType.fundingSubTypes` to `FetchType.EAGER`, but as `FundingSubType.fundingType` is also `FetchType.EAGER`, there would be a cyclic reference in the mapper class. So it's better to have another endpoint to return subTypes for a fundingType. There're some similar examples in TCS, eg.  [GET /people/{id}/placements](https://github.com/Health-Education-England/TIS-TCS/blob/e7cddfabf589c4f1f636624f38de93cc28f9260d/tcs-service/src/main/java/com/transformuk/hee/tis/tcs/service/api/PersonResource.java#L408).

~~There's one thing I'm not sure, which is about where we should have this new endpoint, in FundingTypeResource or in FundingSubTypeResource?
I personally think FundingSubTypeResource is better because this endpoint only needs to interact with FundingSubType repository & servie. Please let me know if you have a different opinion.~~
I have put the new endpoint in FundingTypeResource.

TIS21-5380