### PR TITLE
refactor:use HttpStatusCodeException.getStatusCode

### DIFF
--- a/reference-client/pom.xml
+++ b/reference-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>reference-client</artifactId>
-  <version>4.14.1</version>
+  <version>4.14.2</version>
 
   <properties>
     <java.version>1.8</java.version>

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -60,7 +60,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
+++ b/reference-client/src/main/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImpl.java
@@ -61,6 +61,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -437,9 +438,16 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
               new ParameterizedTypeReference<List<SiteDTO>>() {
               });
       return responseEntity.getBody();
-    } catch (HttpClientErrorException.NotFound e) {
-      LOG.info("Not found sites for ids [{}].", joinedIds);
-      return Collections.emptyList();
+    } catch (HttpStatusCodeException e) {
+      // We used HttpClientErrorException.NotFound which is added in springframework 5.
+      // But, generic upload service still uses springframework 4, and
+      // HttpClientErrorException.NotFound cannot be recognised there.
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        LOG.info("Not found sites for ids [{}].", joinedIds);
+        return Collections.emptyList();
+      } else {
+        throw e;
+      }
     } catch (Exception e) {
       LOG.error(
           "Exception during find sites id in for ids [{}],"
@@ -536,9 +544,16 @@ public class ReferenceServiceImpl extends AbstractClientService implements Refer
               new ParameterizedTypeReference<List<GradeDTO>>() {
               });
       return responseEntity.getBody();
-    } catch (HttpClientErrorException.NotFound e) {
-      LOG.info("Not found grades for ids [{}].", joinedIds);
-      return Collections.emptyList();
+    } catch (HttpStatusCodeException e) {
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        // We used HttpClientErrorException.NotFound which is added in springframework 5.
+        // But, generic upload service still uses springframework 4, and
+        // HttpClientErrorException.NotFound cannot be recognised there.
+        LOG.info("Not found grades for ids [{}].", joinedIds);
+        return Collections.emptyList();
+      } else {
+        throw e;
+      }
     } catch (Exception e) {
       LOG.error(
           "Exception during find grade id in for ids [{}], "

--- a/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
+++ b/reference-client/src/test/java/com/transformuk/hee/tis/reference/client/impl/ReferenceServiceImplTest.java
@@ -55,7 +55,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpClientErrorException.NotFound;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 


### PR DESCRIPTION
We used HttpClientErrorException.NotFound which is added in springframework 5. But, generic upload service still uses springframework 4, and HttpClientErrorException.NotFound cannot be recognised there.

TIS-SHED