### PR TITLE
feat: return clear message on contact duplication

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.35.0</version>
+  <version>3.36.0</version>
   <packaging>war</packaging>
 
   <prerequisites>

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/LocalOfficeContactResource.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/LocalOfficeContactResource.java
@@ -60,7 +60,6 @@ public class LocalOfficeContactResource {
     this.validator = validator;
   }
 
-
   /**
    * POST : Create a new local office contact.
    *

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/validation/LocalOfficeContactValidator.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/api/validation/LocalOfficeContactValidator.java
@@ -3,6 +3,9 @@ package com.transformuk.hee.tis.reference.service.api.validation;
 import com.transformuk.hee.tis.reference.api.dto.LocalOfficeContactDto;
 import com.transformuk.hee.tis.reference.service.exception.CustomParameterizedException;
 import com.transformuk.hee.tis.reference.service.exception.ErrorConstants;
+import com.transformuk.hee.tis.reference.service.model.LocalOfficeContact;
+import com.transformuk.hee.tis.reference.service.repository.LocalOfficeContactRepository;
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.common.annotationfactory.AnnotationDescriptor;
 import org.hibernate.annotations.common.annotationfactory.AnnotationFactory;
@@ -18,10 +21,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class LocalOfficeContactValidator {
 
+  private final LocalOfficeContactRepository repository;
+
   private final EmailValidator emailValidator;
   private final URLValidator urlValidator;
 
-  public LocalOfficeContactValidator() {
+  public LocalOfficeContactValidator(LocalOfficeContactRepository repository) {
+    this.repository = repository;
     emailValidator = new EmailValidator();
 
     urlValidator = new URLValidator();
@@ -44,9 +50,22 @@ public class LocalOfficeContactValidator {
     boolean isValid = emailValidator.isValid(contact, null) || urlValidator.isValid(contact, null);
 
     if (!isValid) {
-      String message = String.format("Contact %s was not a valid Email or HTTPS URL.", contact);
+      String message = String.format("Contact '%s' was not a valid Email or HTTPS URL.", contact);
       log.warn(message);
       throw new CustomParameterizedException(message, ErrorConstants.ERR_VALIDATION);
+    }
+
+    // Do not allow inserting a duplicate contact.
+    if (dto.getId() == null) {
+      List<LocalOfficeContact> existingContacts = repository.findByContactTypeIdAndLocalOfficeUuid(
+          dto.getContactType().getId(), dto.getLocalOffice().getUuid());
+
+      if (!existingContacts.isEmpty()) {
+        String message = String.format("A '%s' contact already exists for the '%s' Local Office.",
+            dto.getContactType().getLabel(), dto.getLocalOffice().getName());
+        log.warn(message);
+        throw new CustomParameterizedException(message, ErrorConstants.ERR_VALIDATION);
+      }
     }
   }
 }

--- a/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/LocalOfficeContactRepository.java
+++ b/reference-service/src/main/java/com/transformuk/hee/tis/reference/service/repository/LocalOfficeContactRepository.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.reference.service.repository;
 
 import com.transformuk.hee.tis.reference.service.model.LocalOfficeContact;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -13,4 +14,6 @@ import org.springframework.stereotype.Repository;
 public interface LocalOfficeContactRepository extends JpaRepository<LocalOfficeContact, UUID>,
     JpaSpecificationExecutor<LocalOfficeContact> {
 
+  List<LocalOfficeContact> findByContactTypeIdAndLocalOfficeUuid(UUID contactTypeId,
+      UUID localOfficeUuid);
 }

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LocalOfficeContactResourceIntTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/LocalOfficeContactResourceIntTest.java
@@ -26,17 +26,16 @@ import com.transformuk.hee.tis.reference.service.service.mapper.LocalOfficeConta
 import java.util.List;
 import java.util.UUID;
 import javax.persistence.EntityManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,19 +45,12 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * @see LocalOfficeContactResource
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = Application.class)
-public class LocalOfficeContactResourceIntTest {
+class LocalOfficeContactResourceIntTest {
 
   private static final String DEFAULT_CONTACT = "contact@example.com";
   private static final String UPDATED_CONTACT = "new-contact@example.com";
-  private static final String DEFAULT_CODE = "AAAAAAAAAA";
-  private static final String UPDATED_CODE = "BBBBBBBBBB";
-  private static final String UNENCODED_CODE = "Te$t Code";
-
-  private static final String DEFAULT_LABEL = "AAAAAAAAAA";
-  private static final String UPDATED_LABEL = "BBBBBBBBBB";
-  private static final String UNENCODED_LABEL = "Te$t Label";
 
   @Autowired
   private LocalOfficeContactRepository repository;
@@ -131,8 +123,8 @@ public class LocalOfficeContactResourceIntTest {
     return entity;
   }
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     MockitoAnnotations.initMocks(this);
     LocalOfficeContactResource controller = new LocalOfficeContactResource(service, mapper,
         validator);
@@ -142,8 +134,8 @@ public class LocalOfficeContactResourceIntTest {
         .setMessageConverters(jacksonMessageConverter).build();
   }
 
-  @Before
-  public void initTest() {
+  @BeforeEach
+  void initTest() {
     entity = createEntity(em);
     entity.setContactType(contactTypeRepository.saveAndFlush(entity.getContactType()));
     entity.setLocalOffice(localOfficeRepository.saveAndFlush(entity.getLocalOffice()));
@@ -151,7 +143,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void createLocalOfficeContact() throws Exception {
+  void createLocalOfficeContact() throws Exception {
     int databaseSizeBeforeCreate = repository.findAll().size();
 
     // Create the LocalOfficeContact.
@@ -170,9 +162,9 @@ public class LocalOfficeContactResourceIntTest {
     assertThat(testLocalOfficeContact.getContactType()).isEqualTo(entity.getContactType());
   }
 
-  @Test(expected = DataIntegrityViolationException.class)
+  @Test
   @Transactional
-  public void createLocalOfficeContactWithDuplicateIndex() throws Exception {
+  void createLocalOfficeContactWithDuplicateIndex() throws Exception {
     // Create the LocalOfficeContactType.
     LocalOfficeContactDto dto = mapper.toDto(entity);
     mockMvc.perform(post("/api/local-office-contacts")
@@ -183,15 +175,12 @@ public class LocalOfficeContactResourceIntTest {
     mockMvc.perform(post("/api/local-office-contacts")
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtil.convertObjectToJsonBytes(dto)))
-        .andExpect(status().isCreated());
-
-    // The above insert will not fail until flushed.
-    repository.flush();
+        .andExpect(status().isBadRequest());
   }
 
   @Test
   @Transactional
-  public void createLocalOfficeContactWithExistingId() throws Exception {
+  void createLocalOfficeContactWithExistingId() throws Exception {
     int databaseSizeBeforeCreate = repository.findAll().size();
 
     // Create the LocalOfficeContact with an existing ID.
@@ -211,7 +200,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void createLocalOfficeContactWithInvalidContact() throws Exception {
+  void createLocalOfficeContactWithInvalidContact() throws Exception {
     int databaseSizeBeforeCreate = repository.findAll().size();
 
     // Create the LocalOfficeContact with an invalid contact.
@@ -231,7 +220,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void checkContactTypeIsRequired() throws Exception {
+  void checkContactTypeIsRequired() throws Exception {
     int databaseSizeBeforeTest = repository.findAll().size();
     // Set the field null.
     entity.setContactType(null);
@@ -250,7 +239,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void checkLocalOfficeIsRequired() throws Exception {
+  void checkLocalOfficeIsRequired() throws Exception {
     int databaseSizeBeforeTest = repository.findAll().size();
     // Set the field null.
     entity.setLocalOffice(null);
@@ -269,7 +258,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getAllLocalOfficeContacts() throws Exception {
+  void getAllLocalOfficeContacts() throws Exception {
     // Initialize the database.
     repository.saveAndFlush(entity);
 
@@ -287,7 +276,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithColumnFilter() throws Exception {
+  void getLocalOfficeContactsWithColumnFilter() throws Exception {
     // Initialize the database.
     repository.saveAndFlush(entity);
 
@@ -314,7 +303,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithQueryMatchingContact() throws Exception {
+  void getLocalOfficeContactsWithQueryMatchingContact() throws Exception {
     // Initialize the database.
     LocalOfficeContact entity = createEntity(em, UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
@@ -340,7 +329,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithQueryMatchingLocalOfficeAbbreviation() throws Exception {
+  void getLocalOfficeContactsWithQueryMatchingLocalOfficeAbbreviation() throws Exception {
     // Initialize the database.
     LocalOfficeContact entity = createEntity(em, UUID.randomUUID().toString(), "TSTABR");
     entity.setContactType(contactTypeRepository.saveAndFlush(entity.getContactType()));
@@ -363,7 +352,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithQueryMatchingLocalOfficeName() throws Exception {
+  void getLocalOfficeContactsWithQueryMatchingLocalOfficeName() throws Exception {
     // Initialize the database.
     LocalOfficeContact entity = createEntity(em, UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
@@ -389,7 +378,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithQueryMatchingContactTypeCode() throws Exception {
+  void getLocalOfficeContactsWithQueryMatchingContactTypeCode() throws Exception {
     // Initialize the database.
     LocalOfficeContact entity = createEntity(em, "TSTCODE", UUID.randomUUID().toString());
     entity.setContactType(contactTypeRepository.saveAndFlush(entity.getContactType()));
@@ -412,7 +401,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContactsWithQueryMatchingContactTypeLabel() throws Exception {
+  void getLocalOfficeContactsWithQueryMatchingContactTypeLabel() throws Exception {
     // Initialize the database.
     LocalOfficeContact entity = createEntity(em, UUID.randomUUID().toString(),
         UUID.randomUUID().toString());
@@ -440,7 +429,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getLocalOfficeContact() throws Exception {
+  void getLocalOfficeContact() throws Exception {
     // Initialize the database.
     repository.saveAndFlush(entity);
 
@@ -457,7 +446,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void getNonExistingLocalOfficeContact() throws Exception {
+  void getNonExistingLocalOfficeContact() throws Exception {
     // Get the contact.
     mockMvc.perform(get("/api/local-office-contacts/{id}", UUID.randomUUID()))
         .andExpect(status().isNotFound());
@@ -465,7 +454,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void updateLocalOfficeContact() throws Exception {
+  void updateLocalOfficeContact() throws Exception {
     // Initialize the database.
     repository.saveAndFlush(entity);
     int databaseSizeBeforeUpdate = repository.findAll().size();
@@ -503,7 +492,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void updateNonExistingLocalOfficeContact() throws Exception {
+  void updateNonExistingLocalOfficeContact() throws Exception {
     int databaseSizeBeforeUpdate = repository.findAll().size();
 
     // Create the LocalOfficeContact.
@@ -522,7 +511,7 @@ public class LocalOfficeContactResourceIntTest {
 
   @Test
   @Transactional
-  public void updateLocalOfficeContactWithInvalidContact() throws Exception {
+  void updateLocalOfficeContactWithInvalidContact() throws Exception {
     // Initialize the database.
     repository.saveAndFlush(entity);
     int databaseSizeBeforeUpdate = repository.findAll().size();

--- a/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/validation/LocalOfficeContactValidatorTest.java
+++ b/reference-service/src/test/java/com/transformuk/hee/tis/reference/service/api/validation/LocalOfficeContactValidatorTest.java
@@ -1,11 +1,24 @@
 package com.transformuk.hee.tis.reference.service.api.validation;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.transformuk.hee.tis.reference.api.dto.LocalOfficeContactDto;
+import com.transformuk.hee.tis.reference.api.dto.LocalOfficeContactTypeDto;
+import com.transformuk.hee.tis.reference.api.dto.LocalOfficeDTO;
 import com.transformuk.hee.tis.reference.service.exception.CustomParameterizedException;
+import com.transformuk.hee.tis.reference.service.model.LocalOfficeContact;
+import com.transformuk.hee.tis.reference.service.repository.LocalOfficeContactRepository;
+import java.util.Collections;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -13,10 +26,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 class LocalOfficeContactValidatorTest {
 
   private LocalOfficeContactValidator validator;
+  private LocalOfficeContactRepository repository;
 
   @BeforeEach
   void setUp() {
-    validator = new LocalOfficeContactValidator();
+    repository = mock(LocalOfficeContactRepository.class);
+    validator = new LocalOfficeContactValidator(repository);
   }
 
   @ParameterizedTest
@@ -26,9 +41,14 @@ class LocalOfficeContactValidatorTest {
       "https://valid.tis.nhs.uk",
       "https://valid.tis.nhs.uk/sub"
   })
-  void shouldBeValidWhenAnEmailOrUrl(String contact) {
+  void shouldBeValidWhenAnEmailOrUrlAndUnique(String contact) {
     LocalOfficeContactDto dto = new LocalOfficeContactDto();
     dto.setContact(contact);
+    dto.setContactType(new LocalOfficeContactTypeDto());
+    dto.setLocalOffice(new LocalOfficeDTO());
+
+    when(repository.findByContactTypeIdAndLocalOfficeUuid(any(), any())).thenReturn(
+        Collections.emptyList());
 
     assertDoesNotThrow(() -> validator.validate(dto));
   }
@@ -44,6 +64,65 @@ class LocalOfficeContactValidatorTest {
   void shouldNotBeValidWhenNotAnEmailOrUrl(String contact) {
     LocalOfficeContactDto dto = new LocalOfficeContactDto();
     dto.setContact(contact);
-    assertThrows(CustomParameterizedException.class, () -> validator.validate(dto));
+    dto.setContactType(new LocalOfficeContactTypeDto());
+    dto.setLocalOffice(new LocalOfficeDTO());
+
+    CustomParameterizedException exception = assertThrows(CustomParameterizedException.class,
+        () -> validator.validate(dto));
+
+    assertThat("Unexpected message.", exception.getMessage(), is(
+        String.format("Contact '%s' was not a valid Email or HTTPS URL.", contact)));
+  }
+
+  @Test
+  void shouldNotBeValidWhenDuplicateIndexOnCreate() {
+    LocalOfficeContactTypeDto contactType = new LocalOfficeContactTypeDto();
+    UUID contactTypeId = UUID.randomUUID();
+    contactType.setId(contactTypeId);
+    contactType.setLabel("TYPE_LABEL");
+
+    LocalOfficeDTO localOffice = new LocalOfficeDTO();
+    UUID localOfficeUuid = UUID.randomUUID();
+    localOffice.setUuid(localOfficeUuid);
+    localOffice.setName("LO_NAME");
+
+    LocalOfficeContactDto dto = new LocalOfficeContactDto();
+    dto.setContact("duplicate@tis.nhs.uk");
+    dto.setContactType(contactType);
+    dto.setLocalOffice(localOffice);
+
+    when(repository.findByContactTypeIdAndLocalOfficeUuid(any(), any())).thenReturn(
+        Collections.singletonList(new LocalOfficeContact()));
+
+    CustomParameterizedException exception = assertThrows(CustomParameterizedException.class,
+        () -> validator.validate(dto));
+
+    assertThat("Unexpected message.", exception.getMessage(),
+        is("A 'TYPE_LABEL' contact already exists for the 'LO_NAME' Local Office."));
+    verify(repository).findByContactTypeIdAndLocalOfficeUuid(contactTypeId, localOfficeUuid);
+  }
+
+  @Test
+  void shouldBeValidWhenDuplicateIndexOnUpdate() {
+    LocalOfficeContactTypeDto contactType = new LocalOfficeContactTypeDto();
+    UUID contactTypeId = UUID.randomUUID();
+    contactType.setId(contactTypeId);
+    contactType.setLabel("TYPE_LABEL");
+
+    LocalOfficeDTO localOffice = new LocalOfficeDTO();
+    UUID localOfficeUuid = UUID.randomUUID();
+    localOffice.setUuid(localOfficeUuid);
+    localOffice.setName("LO_NAME");
+
+    LocalOfficeContactDto dto = new LocalOfficeContactDto();
+    dto.setId(UUID.randomUUID());
+    dto.setContact("duplicate@tis.nhs.uk");
+    dto.setContactType(contactType);
+    dto.setLocalOffice(localOffice);
+
+    when(repository.findByContactTypeIdAndLocalOfficeUuid(any(), any())).thenReturn(
+        Collections.singletonList(new LocalOfficeContact()));
+
+    assertDoesNotThrow(() -> validator.validate(dto));
   }
 }


### PR DESCRIPTION
When a contact insert is rejected due to a duplicate LocalOffice/ContactType combination the client receives a generic "Internal Service Error" message.

Update the LocalOfficeContactValidator to check for this scenario and respond with a more informative message.

TIS21-5727
TIS21-5668