### PR TITLE
chore: increment POM version

### DIFF
--- a/reference-service/pom.xml
+++ b/reference-service/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>reference-service</artifactId>
-  <version>3.37.0</version>
+  <version>3.38.0</version>
   <packaging>war</packaging>
 
   <prerequisites>


### PR DESCRIPTION
TIS21-6266: NDW exports old names for downstream systems no matter if local office names are updated