### PR TITLE
chore: add 2 gender records for nimdta

### DIFF
--- a/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.83__add_gender.sql
+++ b/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.83__add_gender.sql
@@ -1,0 +1,4 @@
+INSERT INTO `Gender`(`code`, `label`, `status`, `uuid`)
+VALUES
+  ('Male (including trans man)','Male (including trans man)','CURRENT','766989c4-f046-11ef-bc3b-0638a616fc76'),
+  ('Female (including trans woman)','Female (including trans woman)','CURRENT','85780ee1-f046-11ef-bc3b-0638a616fc76');


### PR DESCRIPTION
2 gender records have added on Prod, this script will add them with the same UUID on nimdta. Tested with nimdta db locally.

TIS21-7020