### PR TITLE
chore: upgrade "actions/upload-artifact"

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: mvn install -DskipTests
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-jar
           path: reference-*/target/*.jar
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: build-artifacts
 


### PR DESCRIPTION
v3 is deprecated, and cicd workflow is blocked.

no-ticket