### PR TITLE
chore: add a marital status record for nimdta

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -45,7 +45,7 @@ jobs:
         run: mvn install -DskipTests
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-jar
           path: reference-*/target/*.jar
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: build-artifacts
 

--- a/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.84__add_marital_status.sql
+++ b/reference-service/src/main/resources/db/migration/tenant/nimdta/V3.84__add_marital_status.sql
@@ -1,0 +1,3 @@
+INSERT INTO `MaritalStatus`(`code`, `label`, `status`, `uuid`)
+VALUES
+  ('Married / Civil Partnership','Married / Civil Partnership','CURRENT','dc9e7619-f05a-11ef-bc3b-0638a616fc76');


### PR DESCRIPTION
1. A record has been added to Prod, this script will add it with the same UUID on nimdta. Tested locally.
2. Upgrade deprecated github actions as previous CICD failed due to action deprecation: https://github.com/Health-Education-England/TIS-REFERENCE/actions/runs/13456577655

TIS21-7020